### PR TITLE
xml_root is not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ xml_text(x)
 xml_find(x, ".//baz")
 
 h <- html("<html><p>Hi <b>!")
-xml_root(h)
+h
 xml_name(h)
+xml_text(h)
 ```
 
 There are two key classes:


### PR DESCRIPTION
`xml_root` is not defined. Use other examples to demonstrate the ability of parsing incomplete html document.