### PR TITLE
Respect the indent parameter when printing xml_structure.

### DIFF
--- a/R/xml_structure.R
+++ b/R/xml_structure.R
@@ -13,15 +13,15 @@
 #' rproj <- read_html(system.file("extdata","r-project.html", package = "xml2"))
 #' xml_structure(rproj)
 #' xml_structure(xml_find_all(rproj, ".//p"))
-xml_structure <- function(x, indent = 0) {
+xml_structure <- function(x, indent = 2) {
   UseMethod("xml_structure")
 }
 
 #' @export
-xml_structure.xml_nodeset <-  function(x, indent = 0) {
+xml_structure.xml_nodeset <-  function(x, indent = 2) {
   for (i in seq_along(x)) {
     cat("[[", i, "]]\n", sep = "")
-    xml_structure(x[[i]], indent = indent)
+    print_xml_structure(x[[i]], indent = indent)
     cat("\n")
   }
 
@@ -29,8 +29,14 @@ xml_structure.xml_nodeset <-  function(x, indent = 0) {
 }
 
 #' @export
-xml_structure.xml_node <-  function(x, indent = 0) {
-  padding <- paste(rep(" ", indent), collapse = "")
+xml_structure.xml_node <-  function(x, indent = 2) {
+    print_xml_structure(x, indent = indent)
+
+    invisible()
+}
+
+print_xml_structure <- function(x, prefix = 0, indent = 2) {
+  padding <- paste(rep(" ", prefix), collapse = "")
   type <- xml_type(x)
 
   if (type == "element") {
@@ -43,27 +49,10 @@ xml_structure.xml_node <-  function(x, indent = 0) {
 
     node <- paste0("<", xml_name(x), attr_str, ">")
 
-    if (one_child(x)) {
-      cat(padding, node, " ", sep = "")
-      xml_structure(xml_contents(x)[[1]], indent = 0)
-    } else {
-      cat(padding, node, "\n", sep = "")
-      lapply(xml_contents(x), xml_structure, indent = indent + 2)
-    }
-
+    cat(padding, node, "\n", sep = "")
+    lapply(xml_contents(x),
+      print_xml_structure, prefix = prefix + indent, indent = indent)
   } else {
     cat(padding, "{", type, "}\n", sep = "")
   }
-
-  invisible()
-}
-
-one_child <- function(x) {
-  children <- xml_contents(x)
-  if (length(children) == 0) return(FALSE)
-  if (length(children) > 1) return(FALSE)
-
-  grandchildren <- xml_contents(children[[1]])
-
-  length(grandchildren) == 0
 }

--- a/man/xml_structure.Rd
+++ b/man/xml_structure.Rd
@@ -4,7 +4,7 @@
 \alias{xml_structure}
 \title{Show the structure of an html/xml document.}
 \usage{
-xml_structure(x, indent = 0)
+xml_structure(x, indent = 2)
 }
 \arguments{
 \item{x}{HTML/XML document (or part there of)}


### PR DESCRIPTION
As above. The indent parameter is now actually used when printing indentation for `xml_structure()` when previously it was always using 2 chars.