### PR TITLE
Package does not contain xml function

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ devtools::install_github("hadley/xml2")
 
 ```R
 library("xml2")
-x <- xml("<foo> <bar> text <baz/> </bar> </foo>")
+x <- read_xml("<foo> <bar> text <baz/> </bar> </foo>")
 x
 
 xml_name(x)


### PR DESCRIPTION
The README has code that does not work. Swap function xml out for read_xml.