### PR TITLE
Container based travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,38 @@
 # Sample .travis.yml for R projects from https://github.com/craigcitro/r-travis
+language: c
+sudo: false
 
-language: r
-sudo: required
-warnings_are_errors: true
+addons:
+  apt:
+    sources:
+      - r-packages-precise
+    packages:
+      - r-base-dev
+      - r-recommended
+      - pandoc
+      - libxml2-dev
 
-apt_packages:
-  - libxml2-dev
+env:
+  - R_LIBS_USER=~/R/library
+
+cache:
+  directories:
+    $R_LIBS_USER
+
+before_script:
+  - mkdir -p "$R_LIBS_USER"
+  - Rscript -e 'if (length(find.package("devtools", quiet = TRUE)) == 0L) { install.packages("devtools", repos = "http://cran.rstudio.com") }'
+  - Rscript -e 'library(devtools);update_packages("devtools", repos = "http://cran.rstudio.com")'
+  - Rscript -e 'library(devtools);install_deps(repos = "http://cran.rstudio.com", dependencies = TRUE)'
+
+script:
+  - Rscript -e 'devtools::check()'
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+
+after_success:
+  - Rscript -e 'if (length(find.package("covr", quiet = TRUE)) == 0L) { install.packages("covr", repos = "http://cran.rstudio.com") }'
+  - Rscript -e 'covr::codecov()'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # xml2
+[![Coverage Status](https://img.shields.io/codecov/c/github/jimhester/xml2/master.svg)](https://codecov.io/github/jimhester/xml2?branch=master)
 
 The xml2 package is a binding to [libxml2](http://xmlsoft.org), making it easy to work with HTML and XML from R. The API is somewhat inspired by [jQuery](http://jquery.com).
 


### PR DESCRIPTION
Use container based travis file with dependency caching and coverage
This will give us much faster builds going forward. To see the coverage
reports we will need to enable them at codecov.io