### PR TITLE
Changing configure script execution shell for portability.

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Anticonf (tm) script by Jeroen Ooms (2015)
 # This script will query 'pkg-config' for the required cflags and ldflags.
 # If pkg-config is unavailable or does not find the library, try setting


### PR DESCRIPTION
Referencing /bin/bash is not portable and /bin/sh should be used instead. There are no bash-only features used in this script so there should be no problems with the change.