### PR TITLE
* ENHANCE: Add test case causing a hard crash under 0.1.2.9000

### DIFF
--- a/tests/testthat/test-xml_find.R
+++ b/tests/testthat/test-xml_find.R
@@ -1,5 +1,12 @@
 context("xml_find")
 
+# Find all --------------------------------------------------------------------
+
+test_that("xml_find_all raises an error given an invalid XPath. ", {
+  x <- read_xml("<foo> <bar> text <baz/> </bar> </foo>")
+  expect_error(xml_find_all(x, NULL))
+})
+
 # Find one ---------------------------------------------------------------------
 
 test_that("xml_find_one returns a missing object if no match", {


### PR DESCRIPTION
This test case crashes R with the following C++ exception: 
```
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
```