### PR TITLE
add only_leaves support to xml2::as_list

### DIFF
--- a/R/as_list.R
+++ b/R/as_list.R
@@ -15,6 +15,7 @@
 #' }
 #'
 #' @inheritParams xml_name
+#' @param only_leaves Should only content from leaf nodes be included?
 #' @param ... Needed for compatability with generic. Unused.
 #' @export
 #' @examples
@@ -22,18 +23,22 @@
 #' as_list(read_xml("<foo> <bar><baz /></bar> </foo>"))
 #' as_list(read_xml("<foo id = 'a'></foo>"))
 #' as_list(read_xml("<foo><bar id='a'/><bar id='b'/></foo>"))
-as_list <- function(x, ns = character(), ...) {
+as_list <- function(x, ns = character(), only_leaves = FALSE, ...) {
   UseMethod("as_list")
 }
 
 #' @export
-as_list.xml_missing <- function(x, ns = character(), ...) {
+as_list.xml_missing <- function(x, ns = character(), only_leaves = FALSE, ...) {
   list()
 }
 
 #' @export
-as_list.xml_node <- function(x, ns = character(), ...) {
-  contents <- xml_contents(x)
+as_list.xml_node <- function(x, ns = character(), only_leaves = FALSE, ...) {
+  if (only_leaves && length(xml_children(x)) > 0)
+    contents <- xml_children(x)
+  else
+    contents <- xml_contents(x)
+
   if (length(contents) == 0) {
     # Base case - contents
     type <- xml_type(x)
@@ -45,7 +50,7 @@ as_list.xml_node <- function(x, ns = character(), ...) {
 
     out <- list()
   } else {
-    out <- lapply(seq_along(contents), function(i) as_list(contents[[i]], ns = ns))
+    out <- lapply(seq_along(contents), function(i) as_list(contents[[i]], ns = ns, only_leaves = only_leaves))
 
     nms <- ifelse(xml_type(contents) == "element", xml_name(contents, ns = ns), "")
     if (any(nms != "")) {
@@ -62,6 +67,6 @@ as_list.xml_node <- function(x, ns = character(), ...) {
 }
 
 #' @export
-as_list.xml_nodeset <- function(x, ns = character(), ...) {
-  lapply(seq_along(x), function(i) as.list(x[[i]], ns = ns))
+as_list.xml_nodeset <- function(x, ns = character(), only_leaves = FALSE, ...) {
+  lapply(seq_along(x), function(i) as.list(x[[i]], ns = ns, only_leaves = only_leaves))
 }

--- a/man/as_list.Rd
+++ b/man/as_list.Rd
@@ -4,7 +4,7 @@
 \alias{as_list}
 \title{Coerce xml nodes to a list.}
 \usage{
-as_list(x, ns = character(), ...)
+as_list(x, ns = character(), only_leaves = FALSE, ...)
 }
 \arguments{
 \item{x}{A document, node, or node set.}
@@ -15,6 +15,8 @@ qualified with the ns prefix, i.e. if the element \code{bar} is defined
 in namespace \code{foo}, it will be called \code{foo:bar}. (And
 similarly for atttributes). Default namespaces must be given an explicit
 name.}
+
+\item{only_leaves}{Should only content from leaf nodes be included?}
 
 \item{...}{Needed for compatability with generic. Unused.}
 }

--- a/tests/testthat/test-as.list.R
+++ b/tests/testthat/test-as.list.R
@@ -1,6 +1,7 @@
 context("as_list")
 
 list_xml <- function(x) as_list(read_xml(x))
+list_xml_leaves <- function(x) as_list(read_xml(x), only_leaves = TRUE)
 
 test_that("empty elements become empty lists", {
   expect_equal(list_xml("<x></x>"), list())
@@ -19,4 +20,10 @@ test_that("cdata nodes become character vectors", {
 
 test_that("xml attributes become R attibutes", {
   expect_equal(list_xml("<x a='1' b='2'></x>"), structure(list(), a = "1", b = "2"))
+})
+
+test_that("xml leaves elements become leaves list", {
+  expect_equal(list_xml_leaves("<x> <y> <z/></y></x>"), list(y = list(z = list())))
+  expect_equal(list_xml_leaves("<x>\n\t<y>a</y>\n</x>"), list(y = list("a")))
+  expect_equal(list_xml_leaves("<x>a:<y>a</y></x>"), list(y = list("a")))
 })


### PR DESCRIPTION
I spent some time finding ways to use `xml2` to import xml tabular data, not sure if I missed something obvious, but would like to share what I found...

In general, I wanted to avoid writing a big function to parse the XML tree to extract the data I was interested in. While writing this function is feasible, I was planning to use this code on the data import code generation module in RStudio; therefore, it would be really nice to generate something clean that is reusable.

I found a couple scenarios that work quite well.

For instance, for simple tabular XML:

```
<d>
    <r>
        <a>1</a>
        <b>1.1</b>
    </r>
    <r>
        <a>2</a>
        <b>1.2</b>
    </r>
</d>
```

This seems reasonable to me:

```
xml <- "<d><r><a>1</a><b>1.1</b></r><r><a>2</a><b>1.2</b></r></d>"
xml_list <- as_list(read_xml(xml))
View(matrix(unlist(xml_list), nrow = length(xml_list[[1]]), byrow = TRUE))
```

Also, for xml files with data nested in the hierarchy, this turned out to be easy to achieve with xpath:

```
xml <- "<q><c>caption</c><d><r><a>1</a><b>1.1</b></r><r><a>2</a><b>1.2</b></r></d></q>"
xml_list <- as_list(xml_find_one(read_xml(xml), "/q/d"))
View(matrix(unlist(xml_list), nrow = length(xml_list[[1]]), byrow = TRUE))
```

However, the first issue I hit was while loading formatted data:

```
xml <- "<d>\n\t<r><a>1</a><b>1.1</b></r>\n\t<r><a>2</a><b>1.2</b></r>\n</d>"
xml_list <- as_list(read_xml(xml))
View(matrix(unlist(xml_list), nrow = length(xml_list[[1]]), byrow = TRUE))
```

Hence, this PR to introduce an `only_leaves` parameter to filter out anything that is not a leaf element. However, I do wonder if I missed a simpler way to implement this functionality without changing as_list().

While this covers all nicely structured XML tables, there is another set of tables that this won't cover yet, for instance:
- Empty elements: `<d><r><a/><b>1.1</b></r><r><a>2</a><b>1.2</b></r></d>`
- Missing elements: `<d><r><b>1.1</b></r><r><a>2</a><b>1.2</b></r></d>`
- Unordered elements: `<d><r><a>1</a><b>1.1</b></r><r><b>1.2</b><a>2</a></r></d>`

Therefore, I'm not 100% sure it's worth taking a change to `as_list` since there might be other cases worth considering, it seems to me as if we wanted a whole new `as_data_table` function to handle all these cases. I'll be happy to make some extra time to help expand this PR over time, let me know what you think.