### PR TITLE
Make xml_find_{lgl,num,chr} type stable on zero length nodesets

### DIFF
--- a/R/xml_find.R
+++ b/R/xml_find.R
@@ -137,7 +137,7 @@ xml_find_num.xml_node <- function(x, xpath, ns = character()) {
 #' @export
 xml_find_num.xml_nodeset <- function(x, xpath, ns = character()) {
   if (length(x) == 0)
-    return(list())
+    return(numeric())
 
   vapply(x, function(x) xml_find_num(x, xpath = xpath, ns = ns), numeric(1))
 }
@@ -165,7 +165,7 @@ xml_find_chr.xml_node <- function(x, xpath, ns = character()) {
 #' @export
 xml_find_chr.xml_nodeset <- function(x, xpath, ns = character()) {
   if (length(x) == 0)
-    return(list())
+    return(character())
 
   vapply(x, function(x) xml_find_chr(x, xpath = xpath, ns = ns), character(1))
 }
@@ -193,7 +193,7 @@ xml_find_lgl.xml_node <- function(x, xpath, ns = character()) {
 #' @export
 xml_find_lgl.xml_nodeset <- function(x, xpath, ns = character()) {
   if (length(x) == 0)
-    return(list())
+    return(logical())
 
   vapply(x, function(x) xml_find_lgl(x, xpath = xpath, ns = ns), logical(1))
 }


### PR DESCRIPTION
With current behaviour, produces list() which causes errors with
code that assumes they always produce logical, numeric and character
types.

Small example:

```r

x <- read_xml("<body>
       <p>Some <b>text</b>.</p>
       <p>Some <b>other</b> <b>text</b>.</p>
       <p>No bold here!</p>
     </body>")
para <- xml_find_all(x, ".//p")

ns1 <- xml_find_all(x, "//body") # node set with things in it
ns2 <- xml_find_all(x, "//notatag") # empty node set
xml_find_lgl(ns1, "boolean(p)") # TRUE
xml_find_lgl(ns2, "boolean(q)") # list(), rather than logical(0)
```

The current design may be on purpose but the unit tests still pass with this in.  I can add a unit test for this case if you're happy with this new behaviour.