### PR TITLE
Use actual maps for NsMap

### DIFF
--- a/src/xml2_utils.h
+++ b/src/xml2_utils.h
@@ -5,7 +5,7 @@
 #include <libxml/tree.h>
 #include <boost/shared_ptr.hpp>
 #include <boost/typeof/typeof.hpp>
-#include <unordered_map>
+#include <boost/unordered_map.hpp>
 
 inline xmlChar* asXmlChar(std::string x) {
   return (xmlChar*) x.c_str();
@@ -60,7 +60,7 @@ public:
 class NsMap {
 
   // We only store the index to avoid duplicating the data
-  typedef std::unordered_map<std::string, std::string> url2prefix_t;
+  typedef boost::unordered_map<std::string, std::string> url2prefix_t;
 
   url2prefix_t url2prefix;
   std::vector<std::string> order;
@@ -110,9 +110,7 @@ class NsMap {
     if (hasUrl(url))
       return false;
 
-    // Add the valuse to the vectors and add the index to the maps.
-    // We never delete values so we don't have to worry about keeping the
-    // indexes updated.
+    // Add the value to the vector and store the order.
     order.push_back(url);
     url2prefix.insert(url2prefix_t::value_type(url, prefix));
     return true;

--- a/src/xml2_utils.h
+++ b/src/xml2_utils.h
@@ -4,7 +4,6 @@
 #include <Rcpp.h>
 #include <libxml/tree.h>
 #include <boost/shared_ptr.hpp>
-#include <boost/typeof/typeof.hpp>
 #include <boost/unordered_map.hpp>
 
 inline xmlChar* asXmlChar(std::string x) {
@@ -71,8 +70,8 @@ class NsMap {
 
   // Initialise from an existing character vector
   NsMap(Rcpp::CharacterVector x) {
-    BOOST_AUTO(names, Rcpp::as<Rcpp::CharacterVector>(x.attr("names")));
-    for (BOOST_AUTO(i, 0); i < x.size(); ++i) {
+    Rcpp::CharacterVector names = Rcpp::as<Rcpp::CharacterVector>(x.attr("names"));
+    for (std::vector<std::string>::size_type i = 0; i < x.size(); ++i) {
       add(std::string(names[i]), std::string(x[i]));
     }
   }
@@ -82,7 +81,7 @@ class NsMap {
   }
 
   std::string findPrefix(std::string url) {
-    BOOST_AUTO(it, url2prefix.find(url));
+    url2prefix_t::const_iterator it = url2prefix.find(url);
     if (it != url2prefix.end()) {
       return it->second;
     }
@@ -92,7 +91,7 @@ class NsMap {
   }
 
   std::string findUrl(std::string prefix) {
-    for (BOOST_AUTO(it, url2prefix.begin()); it != url2prefix.end(); ++it) {
+    for (url2prefix_t::const_iterator it = url2prefix.begin(); it != url2prefix.end(); ++it) {
       if (it->second == prefix) {
         return it->first;
       }
@@ -121,7 +120,7 @@ class NsMap {
     std::vector<std::string> name;
     name.reserve(order.size());
 
-    for(BOOST_AUTO(it, order.begin());it != order.end(); ++it) {
+    for(std::vector<std::string>::const_iterator it = order.begin();it != order.end(); ++it) {
       name.push_back(url2prefix.at(*it));
     }
     out.attr("names") = Rcpp::wrap(name);

--- a/src/xml2_utils.h
+++ b/src/xml2_utils.h
@@ -5,7 +5,7 @@
 #include <libxml/tree.h>
 #include <boost/shared_ptr.hpp>
 #include <boost/typeof/typeof.hpp>
-#include <map>
+#include <boost/unordered_map.hpp>
 
 inline xmlChar* asXmlChar(std::string x) {
   return (xmlChar*) x.c_str();
@@ -59,12 +59,15 @@ public:
 
 class NsMap {
 
-  // We only store a pointer to the strings in url2prefix to avoid an extra duplication.
-  typedef std::multimap<std::string, std::string> prefix2url_t;
-  typedef std::map<std::string, const std::string*> url2prefix_t;
+  // We only store the index to avoid duplicating the data
+  typedef boost::unordered_multimap<std::string, std::size_t> prefix2url_t;
+  typedef boost::unordered_multimap<std::string, std::size_t> url2prefix_t;
 
   prefix2url_t prefix2url;
   url2prefix_t url2prefix;
+
+  std::vector<std::string> prefix_;
+  std::vector<std::string> url_;
 
   public:
   NsMap() {
@@ -73,7 +76,7 @@ class NsMap {
   // Initialise from an existing character vector
   NsMap(Rcpp::CharacterVector x) {
     BOOST_AUTO(names, Rcpp::as<Rcpp::CharacterVector>(x.attr("names")));
-    for (int i = 0; i < x.size(); ++i) {
+    for (std::size_t i = 0; i < x.size(); ++i) {
       add(std::string(names[i]), std::string(x[i]));
     }
   }
@@ -85,7 +88,7 @@ class NsMap {
   std::string findPrefix(std::string url) {
     BOOST_AUTO(it, url2prefix.find(url));
     if (it != url2prefix.end()) {
-      return *it->second;
+      return prefix_.at(it->second);
     }
 
     Rcpp::stop("Couldn't find prefix for url %s", url);
@@ -95,7 +98,7 @@ class NsMap {
   std::string findUrl(std::string prefix) {
     BOOST_AUTO(it, prefix2url.find(prefix));
     if (it != prefix2url.end()) {
-      return it->second;
+      return url_.at(it->second);
     }
 
     Rcpp::stop("Couldn't find url for prefix %s", prefix);
@@ -110,17 +113,23 @@ class NsMap {
     if (hasUrl(url))
       return false;
 
-    // The return value of multimap.insert is an iterator of the inserted
-    // element. We store the address of the key string as the value in
-    // url2prefix to avoid duplicating the data.
-    BOOST_AUTO(p, prefix2url.insert(prefix2url_t::value_type(prefix, url)));
-    url2prefix.insert(url2prefix_t::value_type(url, &(p->first)));
+    // Add the valuse to the vectors and add the index to the maps.
+    // We never delete values so we don't have to worry about keeping the
+    // indexes updated.
+    std::size_t i = prefix_.size();
+    prefix_.push_back(prefix);
+    url_.push_back(url);
+    prefix2url.insert(prefix2url_t::value_type(prefix, i));
+    url2prefix.insert(url2prefix_t::value_type(url, i));
 
     return true;
   }
 
   Rcpp::CharacterVector out() {
-    return Rcpp::wrap(prefix2url);
+    Rcpp::CharacterVector out = Rcpp::wrap(url_);
+    out.attr("names") = Rcpp::wrap(prefix_);
+
+    return out;
   }
 };
 

--- a/src/xml2_utils.h
+++ b/src/xml2_utils.h
@@ -59,15 +59,15 @@ public:
 
 class NsMap {
 
+  std::vector<std::string> prefix_;
+  std::vector<std::string> url_;
+
   // We only store the index to avoid duplicating the data
-  typedef boost::unordered_multimap<std::string, std::size_t> prefix2url_t;
-  typedef boost::unordered_multimap<std::string, std::size_t> url2prefix_t;
+  typedef boost::unordered_multimap<std::string, std::vector<std::string>::size_type> prefix2url_t;
+  typedef boost::unordered_multimap<std::string, std::vector<std::string>::size_type> url2prefix_t;
 
   prefix2url_t prefix2url;
   url2prefix_t url2prefix;
-
-  std::vector<std::string> prefix_;
-  std::vector<std::string> url_;
 
   public:
   NsMap() {
@@ -76,7 +76,7 @@ class NsMap {
   // Initialise from an existing character vector
   NsMap(Rcpp::CharacterVector x) {
     BOOST_AUTO(names, Rcpp::as<Rcpp::CharacterVector>(x.attr("names")));
-    for (std::size_t i = 0; i < x.size(); ++i) {
+    for (BOOST_AUTO(i, 0); i < x.size(); ++i) {
       add(std::string(names[i]), std::string(x[i]));
     }
   }
@@ -116,11 +116,11 @@ class NsMap {
     // Add the valuse to the vectors and add the index to the maps.
     // We never delete values so we don't have to worry about keeping the
     // indexes updated.
-    std::size_t i = prefix_.size();
-    prefix_.push_back(prefix);
     url_.push_back(url);
-    prefix2url.insert(prefix2url_t::value_type(prefix, i));
-    url2prefix.insert(url2prefix_t::value_type(url, i));
+    prefix2url.insert(prefix2url_t::value_type(prefix, url_.size() - 1));
+
+    prefix_.push_back(prefix);
+    url2prefix.insert(url2prefix_t::value_type(url, prefix_.size() - 1));
 
     return true;
   }


### PR DESCRIPTION
This commit is included in #76, however I wanted to open a separate PR as I wanted to know your thoughts on a few things in particular.

This now uses bidirectional maps to do the lookups instead of the linear search. My original attempt at this was using boost::bimap, however boost::bimap::multimap_of doesn't seem to be part of BH for some reason, so I had to do the bimap by hand.

This probably won't effect performance one way or the other in practice much as the number of namespaces in a document will likely be small, so maybe it is not worth worrying about...

I know you mentioned we are not able to use C++11 due to backwards compatibility concerns, is that still the case? If so what is your thought on the `BOOST_AUTO` usage in this PR?