### PR TITLE
Revert "Changing configure script execution shell for portability."

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Anticonf (tm) script by Jeroen Ooms (2015)
 # This script will query 'pkg-config' for the required cflags and ldflags.
 # If pkg-config is unavailable or does not find the library, try setting


### PR DESCRIPTION
Unfortunately we need to explicitly specify bash to work on Solaris.

Reverts hadley/xml2#61