### PR TITLE
Print attributes of the root node

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -61,6 +61,10 @@ ns_lookup <- function(doc, node, prefix) {
     .Call('xml2_ns_lookup', PACKAGE = 'xml2', doc, node, prefix)
 }
 
+ns_dump <- function(node) {
+    .Call('xml2_ns_dump', PACKAGE = 'xml2', node)
+}
+
 node_name <- function(node, nsMap) {
     .Call('xml2_node_name', PACKAGE = 'xml2', node, nsMap)
 }

--- a/R/classes.R
+++ b/R/classes.R
@@ -25,7 +25,7 @@ as.character.xml_missing <- function(x, ...) {
 #' @export
 print.xml_node <- function(x, width = getOption("width"), max_n = 20, ...) {
   cat("{xml_node}\n")
-  cat("<", xml_name(x), ">\n", sep = "")
+  cat(format(x), "\n", sep = "")
   show_nodes(xml_children(x), width = width, max_n = max_n)
 }
 
@@ -48,7 +48,7 @@ xml_document <- function(doc) {
 print.xml_document <- function(x, width = getOption("width"), max_n = 20, ...) {
   cat("{xml_document}\n")
   if (inherits(x, "xml_node")) {
-    cat("<", xml_name(x), ">\n", sep = "")
+    cat(format(x), "\n", sep = "")
     show_nodes(xml_children(x), width = width, max_n = max_n)
   }
 }
@@ -142,4 +142,23 @@ nodeset_apply.xml_nodeset <- function(x, fun, ...) {
 nodeset_apply.xml_node <- function(x, fun, ...) {
   nodes <- fun(x$node, ...)
   xml_nodeset(lapply(nodes, xml_node, doc = x$doc))
+}
+
+#' @export
+format.xml_node <- function(x, ...) {
+  attrs <- xml_attrs(x)
+  paste("<",
+    paste(
+      c(xml_name(x),
+        format_attributes(attrs)),
+      collapse = " "),
+    ">", sep = "")
+}
+
+format_attributes <- function(x) {
+  if (length(x) == 0) {
+    character(0)
+  } else {
+    paste(names(x), quote_str(x), sep = "=")
+  }
 }

--- a/R/classes.R
+++ b/R/classes.R
@@ -150,7 +150,8 @@ format.xml_node <- function(x, ...) {
   paste("<",
     paste(
       c(xml_name(x),
-        format_attributes(attrs)),
+        c(format_attributes(attrs)),
+        format_attributes(ns_dump(x$node))),
       collapse = " "),
     ">", sep = "")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,3 +11,12 @@ has_names <- function(x) {
     !(is.na(nms) | nms == "")
   }
 }
+
+# non smart quote version of sQuote
+quote_str <- function(x, quote = "\"") {
+  if (!length(x)) {
+    return(character(0))
+  }
+
+  paste0(quote, x, quote)
+}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -184,6 +184,17 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// ns_dump
+CharacterVector ns_dump(XPtrNode node);
+RcppExport SEXP xml2_ns_dump(SEXP nodeSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< XPtrNode >::type node(nodeSEXP);
+    __result = Rcpp::wrap(ns_dump(node));
+    return __result;
+END_RCPP
+}
 // node_name
 CharacterVector node_name(XPtrNode node, CharacterVector nsMap);
 RcppExport SEXP xml2_node_name(SEXP nodeSEXP, SEXP nsMapSEXP) {

--- a/src/xml2_namespace.cpp
+++ b/src/xml2_namespace.cpp
@@ -55,3 +55,25 @@ XPtrNs ns_lookup(XPtrDoc doc, XPtrNode node, std::string prefix) {
   return XPtrNs(ns);
 }
 
+// [[Rcpp::export]]
+CharacterVector ns_dump(XPtrNode node) {
+  std::vector<std::string> prefix;
+  std::vector<std::string> URI;
+  xmlNsPtr next = node.get()->nsDef;
+
+  while(next != NULL) {
+    // default namespace
+    if (next->prefix == NULL) {
+      prefix.push_back("xmlns");
+    } else {
+      prefix.push_back("xmlns:" + Xml2String(next->prefix).asStdString());
+    }
+
+    URI.push_back(Xml2String(next->href).asStdString());
+    next = next->next;
+  }
+  CharacterVector out = Rcpp::wrap(URI);
+  out.attr("names") = Rcpp::wrap(prefix);
+
+  return out;
+}


### PR DESCRIPTION
This works for printing attributes now, but not for namespaces.

libxml2 doesn't seem to have an exported function to print just attributes, or to print a node _without_ recursively printing its children, which is why I had to do this in R code.

Printing namespaces is going to take a little more work as we don't currently have code to retrieve the namespace for a specific node, just the document as a whole.

Fixes #7