### PR TITLE
Only look for attributes for element nodes

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -77,8 +77,8 @@ node_attr <- function(node, name, missing, nsMap) {
     .Call('xml2_node_attr', PACKAGE = 'xml2', node, name, missing, nsMap)
 }
 
-node_attrs <- function(node, nsMap) {
-    .Call('xml2_node_attrs', PACKAGE = 'xml2', node, nsMap)
+node_attrs <- function(node_, nsMap) {
+    .Call('xml2_node_attrs', PACKAGE = 'xml2', node_, nsMap)
 }
 
 node_set_attr <- function(node, name, value, nsMap) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -234,14 +234,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // node_attrs
-CharacterVector node_attrs(XPtrNode node, CharacterVector nsMap);
-RcppExport SEXP xml2_node_attrs(SEXP nodeSEXP, SEXP nsMapSEXP) {
+CharacterVector node_attrs(XPtrNode node_, CharacterVector nsMap);
+RcppExport SEXP xml2_node_attrs(SEXP node_SEXP, SEXP nsMapSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
-    Rcpp::traits::input_parameter< XPtrNode >::type node(nodeSEXP);
+    Rcpp::traits::input_parameter< XPtrNode >::type node_(node_SEXP);
     Rcpp::traits::input_parameter< CharacterVector >::type nsMap(nsMapSEXP);
-    __result = Rcpp::wrap(node_attrs(node, nsMap));
+    __result = Rcpp::wrap(node_attrs(node_, nsMap));
     return __result;
 END_RCPP
 }

--- a/tests/testthat/test-xml_attrs.R
+++ b/tests/testthat/test-xml_attrs.R
@@ -18,6 +18,14 @@ test_that("attributes are correctly found", {
   expect_false(xml_has_attr(x, "id2"))
 })
 
+test_that("returning an attribute node prints properly", {
+  x <- read_xml("<a><b c='1' /></a>")
+
+  t1 <- xml_find_first(x, "//@c")
+
+  expect_equal(format(t1), "<c>")
+})
+
 # Namespaces -------------------------------------------------------------------
 
 # Default namespace doesn't apply to attributes


### PR DESCRIPTION
Fixes #97 

The main issue was for non-element nodes the ns and nsDef structures can be non-null but also invalid as XML_ATTRIBUTE_NODE cannot have its own attributes or namespace definitions. The code assumed they would be NULL but that is clearly not true.

The fix is to only check for attributes if it is an XML_ELEMENT_NODE and return `character()` otherwise.

One other issue this raises is how we want display non-element nodes. Should `format(t1)` be `"c='1'"` or is the previous behavior as `<c>` sufficient. Most of the time I believe people want to work with element nodes, so probably the previous behavior is fine.