### PR TITLE
Fixes for memory leaks found with the LeakSanitizer

### DIFF
--- a/src/xml2_url.cpp
+++ b/src/xml2_url.cpp
@@ -153,8 +153,9 @@ CharacterVector url_unescape(CharacterVector x) {
   for (int i = 0; i < n; ++i) {
     const char* xx = Rf_translateCharUTF8(x[i]);
 
-    const char* unescaped = xmlURIUnescapeString(xx, 0, NULL);
+    char* unescaped = xmlURIUnescapeString(xx, 0, NULL);
     out[i] = (unescaped == NULL) ? NA_STRING : Rf_mkCharCE(unescaped, CE_UTF8);
+    xmlFree(unescaped);
   }
 
   return out;

--- a/tests/testthat/test-modify-xml.R
+++ b/tests/testthat/test-modify-xml.R
@@ -50,12 +50,14 @@ test_that("xml_replace replaces nodes", {
   expect_equal(xml_text(x), "323")
 
   first_child <- xml_children(x)[[1]]
-  xml_replace(first_child, t1)
+  xml_replace(first_child, t1, .copy = FALSE)
   expect_equal(xml_text(x), "123")
+  xml_remove(first_child, free = TRUE)
 
   first_child <- xml_children(x)[[1]]
   xml_replace(first_child, t3, .copy = FALSE)
   expect_equal(xml_text(x), "32")
+  xml_remove(first_child, free = TRUE)
 })
 
 test_that("xml_sibling adds a sibling node", {


### PR DESCRIPTION
The diff looks bigger than it actually is, the main change in node_attr is assigning to a `xmlChar*` rather than a `const xmlChar*`. The former is freed by `Xml2String()` while the latter is not. xmlNsDefinition should return a `const xmlChar*` as previously as no string is allocated by libxml in that case.

`xmlURIUnescapeString` allocates a string if the target parameter is NULL. This is stated expliictly in the docs but is in the code (See https://github.com/GNOME/libxml2/blob/3eaedba1b64180668fdab7ad2eba549586017bf3/uri.c#L1620-L1627)

Those were all the direct leaks detected, I am still working on the indirect leaks.

Addresses #102