### PR TITLE
Use checked_get() in place of get() where possible

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 # xml2 1.0.0
 
+* All C++ functions now use `checked_get()` instead of `get()` where possible,
+  so NULL XPtrs properly throw an error rather than crashing. (@jimhester,
+  #101, #104).
+
 * `xml_integer()` and `xml_double()` functions to make it easy to extract
   integer and double text from nodes (@jimhester, #97, #99).
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -81,8 +81,8 @@ node_attrs <- function(node_, nsMap) {
     .Call('xml2_node_attrs', PACKAGE = 'xml2', node_, nsMap)
 }
 
-node_set_attr <- function(node, name, value, nsMap) {
-    invisible(.Call('xml2_node_set_attr', PACKAGE = 'xml2', node, name, value, nsMap))
+node_set_attr <- function(node_, name, value, nsMap) {
+    invisible(.Call('xml2_node_set_attr', PACKAGE = 'xml2', node_, name, value, nsMap))
 }
 
 node_format <- function(doc, node, format = TRUE, indent = 0L) {

--- a/R/xml_parse.R
+++ b/R/xml_parse.R
@@ -77,7 +77,7 @@ read_html <- function(x, encoding = "", ..., options = c("RECOVER", "NOERROR", "
 
 #' @export
 read_html.default <- function(x, encoding = "", ..., options = c("RECOVER", "NOERROR", "NOBLANKS")) {
-  suppressWarnings(read_xml(x, encoding, ..., as_html = TRUE, options = options))
+  suppressWarnings(read_xml(x, encoding = encoding, ..., as_html = TRUE, options = options))
 }
 
 #' @export

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -246,15 +246,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // node_set_attr
-void node_set_attr(XPtrNode node, std::string name, std::string value, CharacterVector nsMap);
-RcppExport SEXP xml2_node_set_attr(SEXP nodeSEXP, SEXP nameSEXP, SEXP valueSEXP, SEXP nsMapSEXP) {
+void node_set_attr(XPtrNode node_, std::string name, std::string value, CharacterVector nsMap);
+RcppExport SEXP xml2_node_set_attr(SEXP node_SEXP, SEXP nameSEXP, SEXP valueSEXP, SEXP nsMapSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope __rngScope;
-    Rcpp::traits::input_parameter< XPtrNode >::type node(nodeSEXP);
+    Rcpp::traits::input_parameter< XPtrNode >::type node_(node_SEXP);
     Rcpp::traits::input_parameter< std::string >::type name(nameSEXP);
     Rcpp::traits::input_parameter< std::string >::type value(valueSEXP);
     Rcpp::traits::input_parameter< CharacterVector >::type nsMap(nsMapSEXP);
-    node_set_attr(node, name, value, nsMap);
+    node_set_attr(node_, name, value, nsMap);
     return R_NilValue;
 END_RCPP
 }

--- a/src/xml2_doc.cpp
+++ b/src/xml2_doc.cpp
@@ -65,7 +65,7 @@ XPtrDoc doc_parse_raw(RawVector x, std::string encoding,
 // [[Rcpp::export]]
 CharacterVector doc_format(XPtrDoc x) {
   xmlChar *s;
-  xmlDocDumpMemory(x.get(), &s, NULL);
+  xmlDocDumpMemory(x.checked_get(), &s, NULL);
 
   return Xml2String(s).asRString();
 }
@@ -74,7 +74,7 @@ CharacterVector doc_format(XPtrDoc x) {
 void doc_write(XPtrDoc x, std::string path, bool format) {
   FILE* f = fopen(R_ExpandFileName(path.c_str()), "wb");
 
-  int res = xmlDocFormatDump(f, x.get(), format ? 1 : 0);
+  int res = xmlDocFormatDump(f, x.checked_get(), format ? 1 : 0);
   fclose(f);
 
   if (res == -1) {
@@ -84,7 +84,7 @@ void doc_write(XPtrDoc x, std::string path, bool format) {
 
 // [[Rcpp::export]]
 XPtrNode doc_root(XPtrDoc x) {
-  return XPtrNode(xmlDocGetRootElement(x.get()));
+  return XPtrNode(xmlDocGetRootElement(x.checked_get()));
 }
 
 // [[Rcpp::export]]

--- a/src/xml2_namespace.cpp
+++ b/src/xml2_namespace.cpp
@@ -26,7 +26,7 @@ void cache_namespace(xmlNode* node, NsMap* nsMap) {
 CharacterVector doc_namespaces(XPtrDoc doc) {
   NsMap nsMap;
 
-  xmlNode* root = xmlDocGetRootElement(doc.get());
+  xmlNode* root = xmlDocGetRootElement(doc.checked_get());
   cache_namespace(root, &nsMap);
 
   return nsMap.out();
@@ -34,7 +34,7 @@ CharacterVector doc_namespaces(XPtrDoc doc) {
 
 // [[Rcpp::export]]
 XPtrNs ns_lookup_uri(XPtrDoc doc, XPtrNode node, std::string uri) {
-  xmlNsPtr ns = xmlSearchNsByHref(doc.get(), node.get(), asXmlChar(uri));
+  xmlNsPtr ns = xmlSearchNsByHref(doc.checked_get(), node.checked_get(), asXmlChar(uri));
   if (ns == NULL) {
     stop("No namespace with URI `%s` found", uri);
   }
@@ -45,9 +45,9 @@ XPtrNs ns_lookup_uri(XPtrDoc doc, XPtrNode node, std::string uri) {
 XPtrNs ns_lookup(XPtrDoc doc, XPtrNode node, std::string prefix) {
   xmlNsPtr ns = NULL;
   if (prefix.length() == 0) {
-    ns = xmlSearchNs(doc.get(), node.get(), NULL);
+    ns = xmlSearchNs(doc.checked_get(), node.checked_get(), NULL);
   } else {
-    ns = xmlSearchNs(doc.get(), node.get(), asXmlChar(prefix));
+    ns = xmlSearchNs(doc.checked_get(), node.checked_get(), asXmlChar(prefix));
     if (ns == NULL) {
       stop("No namespace with prefix `%s` found", prefix);
     }

--- a/src/xml2_xpath.cpp
+++ b/src/xml2_xpath.cpp
@@ -14,7 +14,7 @@ class XmlSeeker {
 public:
 
   XmlSeeker(XPtrDoc doc, xmlNode* node) : result_(NULL), doc_(doc) {
-    context_ = xmlXPathNewContext(doc.get());
+    context_ = xmlXPathNewContext(doc.checked_get());
     // Set context to current node
     context_->node = node;
   }
@@ -89,7 +89,7 @@ RObject xpath_search(XPtrNode node, XPtrDoc doc, std::string xpath, CharacterVec
   if (num_results == R_PosInf) {
     num_results = INT_MAX;
   }
-  XmlSeeker seeker(doc, node.get());
+  XmlSeeker seeker(doc, node.checked_get());
   seeker.registerNamespace(nsMap);
   return seeker.search(xpath, num_results);
 }

--- a/src/xml_push.cpp
+++ b/src/xml_push.cpp
@@ -57,14 +57,14 @@ XPtrXmlParser xml_push_parser_create(std::string uri) {
 
 bool xml_push_parser_feed(XPtrXmlParser parser, SEXP data) {
   size_t size = Rf_length(data);
-  int res = xmlParseChunk(parser.get(), (const char*) RAW(data), size, 0);
+  int res = xmlParseChunk(parser.checked_get(), (const char*) RAW(data), size, 0);
   if (res)
     Rcpp::stop("XML Parsing Error: %d", res);
   return true;
 }
 
 bool xml_push_parser_complete(XPtrXmlParser parser) {
-  int res = xmlParseChunk(parser.get(), NULL, 0, 1);
+  int res = xmlParseChunk(parser.checked_get(), NULL, 0, 1);
   if (res)
     Rcpp::stop("XML Parsing Error: %d", res);
   return true;
@@ -89,12 +89,12 @@ XPtrHtmlParser html_push_parser_create(std::string uri) {
 }
 
 bool html_push_parser_feed(XPtrHtmlParser parser, SEXP data) {
-  htmlParseChunk(parser.get(), (const char*) RAW(data), Rf_length(data), 0);
+  htmlParseChunk(parser.checked_get(), (const char*) RAW(data), Rf_length(data), 0);
   return true;
 }
 
 bool html_push_parser_complete(XPtrHtmlParser parser) {
-  htmlParseChunk(parser.get(), NULL, 0, 1);
+  htmlParseChunk(parser.checked_get(), NULL, 0, 1);
   return true;
 }
 

--- a/tests/testthat/test-null.R
+++ b/tests/testthat/test-null.R
@@ -1,0 +1,72 @@
+context("Null XPtr")
+
+data <- read_xml("ns-multiple.xml")
+tf <- tempfile()
+on.exit(unlink(tf))
+saveRDS(data, file = tf)
+x <- readRDS(tf)
+
+test_that("accessors all fail rather than crash with NULL Xptrs", {
+
+  expect_error(as_list(x), "external pointer is not valid")
+
+  expect_error(html_structure(x), "external pointer is not valid")
+
+  expect_error(xml_add_child(x, x), "external pointer is not valid")
+  expect_error(xml_add_sibling(x, x), "external pointer is not valid")
+
+  expect_error(xml_attr(x, "foo"), "external pointer is not valid")
+  expect_error(xml_attr(x, "foo") <- "bar", "external pointer is not valid")
+
+  expect_error(xml_attrs(x), "external pointer is not valid")
+  expect_error(xml_attrs(x) <- list(), "external pointer is not valid")
+
+  expect_error(xml_child(x), "external pointer is not valid")
+  expect_error(xml_children(x), "external pointer is not valid")
+
+  expect_error(xml_contents(x), "external pointer is not valid")
+
+  expect_error(xml_double(x), "external pointer is not valid")
+
+  expect_error(xml_find_all(x, ""), "external pointer is not valid")
+  expect_error(xml_find_chr(x, ""), "external pointer is not valid")
+  expect_error(xml_find_first(x, ""), "external pointer is not valid")
+  expect_error(xml_find_lgl(x, ""), "external pointer is not valid")
+  expect_error(xml_find_num(x, ""), "external pointer is not valid")
+
+  expect_error(xml_has_attr(x, ""), "external pointer is not valid")
+
+  expect_error(xml_integer(x), "external pointer is not valid")
+
+  expect_error(xml_length(x), "external pointer is not valid")
+
+  expect_error(xml_name(x), "external pointer is not valid")
+  expect_error(xml_name(x) <- "foo", "external pointer is not valid")
+
+  expect_error(xml_ns(x), "external pointer is not valid")
+  expect_error(xml_ns_strip(x), "external pointer is not valid")
+
+  expect_error(xml_parent(x), "external pointer is not valid")
+  expect_error(xml_parents(x), "external pointer is not valid")
+
+  expect_error(xml_path(x), "external pointer is not valid")
+
+  expect_error(xml_remove(x), "external pointer is not valid")
+
+  expect_error(xml_replace(x, x), "external pointer is not valid")
+
+  expect_error(xml_root(x), "external pointer is not valid")
+
+  expect_error(xml_set_namespace(x, "foo"), "external pointer is not valid")
+
+  expect_error(xml_siblings(x), "external pointer is not valid")
+
+  expect_error(xml_structure(x), "external pointer is not valid")
+
+  expect_error(xml_text(x), "external pointer is not valid")
+  expect_error(xml_text(x) <- "test", "external pointer is not valid")
+
+  expect_error(xml_type(x), "external pointer is not valid")
+
+  expect_error(xml_url(x), "external pointer is not valid")
+})


### PR DESCRIPTION
This ensures we will generate an error rather than crashing on NULL
XPtrs (as happens when round tripping `saveRDS()/readRDS()`.

Fixes #101