### PR TITLE
keep element names when xml node has attributes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # xml2 1.0.0.9000
 
+* `as_list()` now preserves element names when attributes exist, and escapes 
+  XML attributes that conflict with special R attributes (@peterfoley, #115).
+
 # xml2 1.0.0
 
 * All C++ functions now use `checked_get()` instead of `get()` where possible,

--- a/R/as_list.R
+++ b/R/as_list.R
@@ -61,8 +61,7 @@ as_list.xml_node <- function(x, ns = character(), ...) {
   if (length(attr) > 0) {
     # escape special names
     special <- names(attr) %in% c("class", "comment", "dim", "dimnames", "names", "row.names", "tsp")
-    if(any(special))
-      names(attr)[special] <- paste0(".", names(attr)[special])
+    names(attr)[special] <- paste0(".", names(attr)[special])
     attributes(out) <- c(list(names = names(out)), as.list(attr))
   }
 

--- a/R/as_list.R
+++ b/R/as_list.R
@@ -56,7 +56,7 @@ as_list.xml_node <- function(x, ns = character(), ...) {
   # Add xml attributes as R attributes
   attr <- xml_attrs(x, ns = ns)
   if (length(attr) > 0)
-    attributes(out) <- as.list(attr)
+    attributes(out) <- c(list(names=names(out)), as.list(attr))
 
   out
 }

--- a/R/as_list.R
+++ b/R/as_list.R
@@ -56,7 +56,7 @@ as_list.xml_node <- function(x, ns = character(), ...) {
   # Add xml attributes as R attributes
   attr <- xml_attrs(x, ns = ns)
   if (length(attr) > 0)
-    attributes(out) <- c(list(names=names(out)), as.list(attr))
+    attributes(out) <- c(list(names = names(out)), as.list(attr))
 
   out
 }

--- a/R/as_list.R
+++ b/R/as_list.R
@@ -10,7 +10,10 @@
 #'
 #' \itemize{
 #'   \item Other elements, converted to lists.
-#'   \item Attributes, stored as R attributes.
+#'   \item Attributes, stored as R attributes. Attributes that have special meanings in R
+#'           (\code{\link{class}}, \code{\link{comment}}, \code{\link{dim}},
+#'           \code{\link{dimnames}}, \code{\link{names}}, \code{\link{row.names}} and
+#'           \code{\link{tsp}}) are escaped with '.'
 #'   \item Text, stored as a character vector.
 #' }
 #'
@@ -55,8 +58,13 @@ as_list.xml_node <- function(x, ns = character(), ...) {
 
   # Add xml attributes as R attributes
   attr <- xml_attrs(x, ns = ns)
-  if (length(attr) > 0)
+  if (length(attr) > 0) {
+    # escape special names
+    special <- names(attr) %in% c("class", "comment", "dim", "dimnames", "names", "row.names", "tsp")
+    if(any(special))
+      names(attr)[special] <- paste0(".", names(attr)[special])
     attributes(out) <- c(list(names = names(out)), as.list(attr))
+  }
 
   out
 }

--- a/man/as_list.Rd
+++ b/man/as_list.Rd
@@ -30,7 +30,10 @@ children that an element might have:
 
 \itemize{
   \item Other elements, converted to lists.
-  \item Attributes, stored as R attributes.
+  \item Attributes, stored as R attributes. Attributes that have special meanings in R
+          (\code{\link{class}}, \code{\link{comment}}, \code{\link{dim}},
+          \code{\link{dimnames}}, \code{\link{names}}, \code{\link{row.names}} and
+          \code{\link{tsp}}) are escaped with '.'
   \item Text, stored as a character vector.
 }
 }

--- a/tests/testthat/test-as.list.R
+++ b/tests/testthat/test-as.list.R
@@ -23,5 +23,5 @@ test_that("xml attributes become R attibutes", {
 
 test_that("xml names are preserved when attributes exist", {
   expect_equal(list_xml("<x a='1' b='2'><y>3</y><z>4</z></x>"),
-               structure(list(y=list('3'),z=list('4')), names = c("y","z"), a = "1", b = "2"))
+               structure(list(y = list('3'), z = list('4')), names = c("y", "z"), a = "1", b = "2"))
 })

--- a/tests/testthat/test-as.list.R
+++ b/tests/testthat/test-as.list.R
@@ -20,3 +20,8 @@ test_that("cdata nodes become character vectors", {
 test_that("xml attributes become R attibutes", {
   expect_equal(list_xml("<x a='1' b='2'></x>"), structure(list(), a = "1", b = "2"))
 })
+
+test_that("xml names are preserved when attributes exist", {
+  expect_equal(list_xml("<x a='1' b='2'><y>3</y><z>4</z></x>"),
+               structure(list(y=list('3'),z=list('4')), names = c("y","z"), a = "1", b = "2"))
+})

--- a/tests/testthat/test-as.list.R
+++ b/tests/testthat/test-as.list.R
@@ -25,3 +25,8 @@ test_that("xml names are preserved when attributes exist", {
   expect_equal(list_xml("<x a='1' b='2'><y>3</y><z>4</z></x>"),
                structure(list(y = list('3'), z = list('4')), names = c("y", "z"), a = "1", b = "2"))
 })
+
+test_that("special attributes are escaped", {
+  expect_equal(list_xml("<x a='1' b='2' names='esc'><y>3</y><z>4</z></x>"),
+               structure(list(y = list('3'), z = list('4')), names = c("y", "z"), a = "1", b = "2", .names='esc'))
+})


### PR DESCRIPTION
Fix for issue #115.

With this code, xml `names` attribute will still override the element names if both are specified. That's purely in the interest of maximum consistency with existing behavior, but I think the opposite would be more intuitive (element names win).