### PR TITLE
Enable non-character attributes to be set.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -3,6 +3,7 @@
 is_named <- function(x) {
   all(has_names(x))
 }
+
 has_names <- function(x) {
   nms <- names(x)
   if (is.null(nms)) {
@@ -10,6 +11,24 @@ has_names <- function(x) {
   } else {
     !(is.na(nms) | nms == "")
   }
+}
+
+to_named_char <- function(x) {
+  if (is.character(x)) {
+    return(x)
+  }
+
+  if (is.list(x)) {
+    x <- unlist(x)
+  }
+
+  if (!is.character(x)) {
+    nms <- names(x)
+    x <- as.character(x)
+    names(x) <- nms
+  }
+
+  x
 }
 
 # non smart quote version of sQuote

--- a/R/xml_attr.R
+++ b/R/xml_attr.R
@@ -112,6 +112,7 @@ xml_attrs.xml_nodeset <- function(x, ns = character()) {
   if (is.null(value)) {
     node_set_attr(x$node, name = attr, nsMap = ns, "")
   } else {
+    value <- to_named_char(value)
     node_set_attr(x$node, name = attr, nsMap = ns, value)
   }
   x
@@ -135,6 +136,7 @@ xml_attrs.xml_nodeset <- function(x, ns = character()) {
     stop("`value` must be a named character vector or `NULL`", call. = FALSE)
   }
 
+  value <- to_named_char(value)
   attrs <- names(value)
 
   current_attrs <- names(xml_attrs(x, ns = ns))

--- a/tests/testthat/test-xml_attrs.R
+++ b/tests/testthat/test-xml_attrs.R
@@ -107,6 +107,22 @@ test_that("xml_attrs<- modifies all attributes", {
   expect_equivalent(xml_attrs(docs, ns), list(character(0), character(0)))
 })
 
+test_that("xml_attr<- accepts non-character values", {
+  x <- read_xml('<svg><rect /></svg>')
+  svg <- xml_root(x)
+
+  xml_attr(svg, "width") <- 8L
+  expect_that(xml_attr(svg, "width"), equals("8"))
+
+  xml_attr(svg, "height") <- 12.5
+  expect_that(xml_attr(svg, "height"), equals("12.5"))
+
+  expect_that(xml_attrs(svg), equals(c(width = "8", height = "12.5")))
+
+  xml_attrs(svg) <- c(width = 14L, height = 23.45)
+  expect_that(xml_attrs(svg), equals(c(width = "14", height = "23.45")))
+})
+
 test_that("xml_attr<- removes namespaces if desired", {
   xml_attr(x, "xmlns:b") <- NULL
 


### PR DESCRIPTION
This should fix #117. For similar reasons (i.e. working with SVG documents) it would be nice not to have to specify every attribute as a character vector.

Basically this change will cast non-character arguments via `as.character()`.
