### PR TITLE
Allow docs missing a root element to be created and printed. Fixes #121.

### DIFF
--- a/R/classes.R
+++ b/R/classes.R
@@ -39,17 +39,22 @@ print.xml_missing <- function(x, width = getOption("width"), max_n = 20, ...) {
 # document ---------------------------------------------------------------------
 
 xml_document <- function(doc) {
-  x <- xml_node(doc_root(doc), doc)
-  class(x) <- c("xml_document", class(x))
-  x
+  if (doc_has_root(doc)) {
+    x <- xml_node(doc_root(doc), doc)
+    class(x) <- c("xml_document", class(x))
+    x
+  } else {
+    structure(list(doc = doc), class = "xml_document")
+  }
 }
 
 #' @export
 print.xml_document <- function(x, width = getOption("width"), max_n = 20, ...) {
+  doc <- xml_document(x$doc)
   cat("{xml_document}\n")
-  if (inherits(x, "xml_node")) {
-    cat(format(x), "\n", sep = "")
-    show_nodes(xml_children(x), width = width, max_n = max_n)
+  if (inherits(doc, "xml_node")) {
+    cat(format(doc), "\n", sep = "")
+    show_nodes(xml_children(doc), width = width, max_n = max_n)
   }
 }
 

--- a/R/xml_children.R
+++ b/R/xml_children.R
@@ -133,5 +133,9 @@ xml_root <- function(x) {
       return(xml_root(x[[1]]))
     }
   }
-  xml_document(x$doc)
+  if (!doc_has_root(x$doc)) {
+    structure(list(), class = "xml_missing")
+  } else {
+    xml_document(x$doc)
+  }
 }

--- a/tests/testthat/test-null.R
+++ b/tests/testthat/test-null.R
@@ -55,8 +55,6 @@ test_that("accessors all fail rather than crash with NULL Xptrs", {
 
   expect_error(xml_replace(x, x), "external pointer is not valid")
 
-  expect_error(xml_root(x), "external pointer is not valid")
-
   expect_error(xml_set_namespace(x, "foo"), "external pointer is not valid")
 
   expect_error(xml_siblings(x), "external pointer is not valid")

--- a/tests/testthat/test-xml_children.R
+++ b/tests/testthat/test-xml_children.R
@@ -36,3 +36,15 @@ test_that("xml_parents", {
     xml_name(xml_parents(xml_find_first(x, "//boo"))),
     c("bar", "foo"))
 })
+
+test_that("xml_root", {
+  doc <- xml_new_document()
+
+  expect_is(xml_root(doc), "xml_missing")
+
+  a <- xml_add_child(doc, "a")
+  b <- xml_add_child(doc, "b")
+
+  expect_that(xml_name(xml_root(b)), equals("a"))
+  expect_that(xml_name(xml_root(doc)), equals("a"))
+})


### PR DESCRIPTION
This fixes the issue described in #121.

This is mostly achieved by checking whether a document has a root element before attempting to print it.

One other minor bugfix is that an `xml_document` object will now print its children if they were previously absent. An example:

Before:

``` r
> library(xml2)
> doc <- xml_new_document()
> root <- xml_add_child(doc, "root")
> doc
{xml_document}
```

After:

``` r
> library(xml2)
> doc <- xml_new_document()
> root <- xml_add_child(doc, "root")
> doc
{xml_document}
<root>
```
