### PR TITLE
Connection support for writing XML and HTML

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@ windows
 ^src/\.ycm_extra_conf\.py$
 ^src/\.ycm_extra_conf\.pyc$
 ^appveyor\.yml$
+^script\.R$

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ src/*.dll
 src/*.a
 src/Makevars
 inst/doc
+script.R

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # xml2 1.0.0.9000
 
+* `write_xml()` and `write_html()` now accept connections as well as filenames
+  for output. (#157)
+
 * `xml_add_child()` now takes a `.where` argument specifying where to add the
   new children. (#138)
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -165,22 +165,6 @@ node_set_namespace_prefix <- function(doc, node, prefix) {
     invisible(.Call('xml2_node_set_namespace_prefix', PACKAGE = 'xml2', doc, node, prefix))
 }
 
-doc_write_xml <- function(x, path, format) {
-    invisible(.Call('xml2_doc_write_xml', PACKAGE = 'xml2', x, path, format))
-}
-
-doc_write_html <- function(x, path, format) {
-    invisible(.Call('xml2_doc_write_html', PACKAGE = 'xml2', x, path, format))
-}
-
-node_write_xml <- function(n, d, path) {
-    invisible(.Call('xml2_node_write_xml', PACKAGE = 'xml2', n, d, path))
-}
-
-node_write_html <- function(n, d, path) {
-    invisible(.Call('xml2_node_write_html', PACKAGE = 'xml2', n, d, path))
-}
-
 doc_format_xml <- function(x, format = TRUE) {
     .Call('xml2_doc_format_xml', PACKAGE = 'xml2', x, format)
 }
@@ -189,8 +173,24 @@ doc_format_html <- function(x, format = TRUE) {
     .Call('xml2_doc_format_html', PACKAGE = 'xml2', x, format)
 }
 
-doc_write_xml_connection <- function(x, connection, format = TRUE) {
-    invisible(.Call('xml2_doc_write_xml_connection', PACKAGE = 'xml2', x, connection, format))
+xml_save_options <- function() {
+    .Call('xml2_xml_save_options', PACKAGE = 'xml2')
+}
+
+doc_write <- function(x, path, encoding = "UTF-8", options = 1L) {
+    invisible(.Call('xml2_doc_write', PACKAGE = 'xml2', x, path, encoding, options))
+}
+
+doc_write_connection <- function(x, connection, encoding = "UTF-8", options = 1L) {
+    invisible(.Call('xml2_doc_write_connection', PACKAGE = 'xml2', x, connection, encoding, options))
+}
+
+node_write <- function(x, path, encoding = "UTF-8", options = 1L) {
+    invisible(.Call('xml2_node_write', PACKAGE = 'xml2', x, path, encoding, options))
+}
+
+node_write_connection <- function(x, connection, encoding = "UTF-8", options = 1L) {
+    invisible(.Call('xml2_node_write_connection', PACKAGE = 'xml2', x, connection, encoding, options))
 }
 
 node_format_xml <- function(doc, node, format = TRUE, indent = 0L) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,6 +5,10 @@ read_connection_ <- function(con, chunk_size = 64 * 1024L) {
     .Call('xml2_read_connection_', PACKAGE = 'xml2', con, chunk_size)
 }
 
+xml_parse_options <- function() {
+    .Call('xml2_xml_parse_options', PACKAGE = 'xml2')
+}
+
 doc_parse_file <- function(path, encoding = "", as_html = FALSE, options = 0L) {
     .Call('xml2_doc_parse_file', PACKAGE = 'xml2', path, encoding, as_html, options)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -189,6 +189,10 @@ doc_format_html <- function(x, format = TRUE) {
     .Call('xml2_doc_format_html', PACKAGE = 'xml2', x, format)
 }
 
+doc_write_xml_connection <- function(x, connection, format = TRUE) {
+    invisible(.Call('xml2_doc_write_xml_connection', PACKAGE = 'xml2', x, connection, format))
+}
+
 node_format_xml <- function(doc, node, format = TRUE, indent = 0L) {
     .Call('xml2_node_format_xml', PACKAGE = 'xml2', doc, node, format, indent)
 }

--- a/R/paths.R
+++ b/R/paths.R
@@ -1,5 +1,7 @@
-path_to_connection <- function(path) {
-  if (!is.character(path))
+path_to_connection <- function(path, check = c("file", "dir")) {
+  check <- match.arg(check)
+
+  if (!is.character(path) || length(path) != 1L)
     return(path)
 
   if (is_url(path)) {
@@ -10,7 +12,11 @@ path_to_connection <- function(path) {
     }
   }
 
-  path <- check_path(path)
+  if (check == "file") {
+    path <- check_path(path)
+  } else {
+    path <- file.path(check_path(dirname(path)), basename(path))
+  }
   switch(tools::file_ext(path),
     gz = gzfile(path, ""),
     bz2 = bzfile(path, ""),

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,3 +31,10 @@ need_package <- function(pkg) {
 
   stop("Please install ", pkg, " package", call. = FALSE)
 }
+
+# Format the choices for display in Rd
+rd_definition <- function(terms, defs) {
+  paste0("\\describe{\n",
+    paste0("  \\item{", terms, "}{", defs, "}", collapse = "\n"),
+  "\n}")
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,9 +32,11 @@ need_package <- function(pkg) {
   stop("Please install ", pkg, " package", call. = FALSE)
 }
 
-# Format the choices for display in Rd
-rd_definition <- function(terms, defs) {
+# Format the C bitwise flags for display in Rd. The input object is a named
+# integer vector with a 'description' character vector attribute that
+# corresponds to each flag.
+describe_options <- function(x) {
   paste0("\\describe{\n",
-    paste0("  \\item{", terms, "}{", defs, "}", collapse = "\n"),
+    paste0("  \\item{", names(x), "}{", attr(x, "description"), "}", collapse = "\n"),
   "\n}")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,3 +40,29 @@ describe_options <- function(x) {
     paste0("  \\item{", names(x), "}{", attr(x, "description"), "}", collapse = "\n"),
   "\n}")
 }
+
+s_quote <- function(x) paste0("'", x, "'")
+
+# Similar to match.arg, but returns character() with NULL or empty input and
+# errors if any of the inputs are not found (fixing
+# https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=16659)
+parse_options <- function(arg, options) {
+  if (is.numeric(arg)) {
+    return(as.integer(arg))
+  }
+
+  if (is.null(arg) || !nzchar(arg)) {
+    return(0L)
+  }
+
+  # set duplicates.ok = TRUE so any duplicates are counted differently than
+  # non-matches, then take only unique results
+  i <- pmatch(arg, names(options), duplicates.ok = TRUE)
+  if (any(is.na(i))) {
+    stop(sprintf("`options` %s is not a valid option, should be one of %s",
+      s_quote(arg[is.na(i)][1L]),
+      paste(s_quote(names(options)), collapse = ", ")),
+      call. = FALSE)
+  }
+  sum(options[unique(i)])
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -66,3 +66,14 @@ parse_options <- function(arg, options) {
   }
   sum(options[unique(i)])
 }
+
+# Call normalizePath on the directory part of the path, signal an error if it
+# fails
+normalize_output <- function(x) {
+  directory <- tryCatch(normalizePath(dirname(x)),
+    warning = function(e) {
+      stop("Directory ", s_quote(dirname(x)), " does not exist", call. = FALSE)
+    })
+
+  file.path(directory, basename(x))
+}

--- a/R/xml_write.R
+++ b/R/xml_write.R
@@ -37,8 +37,13 @@ write_xml.xml_missing <- function(x, con, ...) {
 #' @export
 write_xml.xml_document <- function(x, con, ..., options = "format", encoding = "UTF-8") {
   options  <- parse_options(options, xml_save_options())
+  con <- path_to_connection(con, check = "dir")
 
   if (inherits(con, "connection")) {
+    if (!isOpen(con)) {
+      open(con, "wb")
+      on.exit(close(con))
+    }
     doc_write_connection(x$doc, con, options = options, encoding = encoding)
   } else {
     if (!(is.character(con) && length(con) == 1 && nzchar(con))) {
@@ -50,13 +55,18 @@ write_xml.xml_document <- function(x, con, ..., options = "format", encoding = "
 
 #' @export
 write_xml.xml_nodeset <- function(x, con, ..., options = "format", encoding = "UTF-8") {
-  if (length(x$nodeset) != 1) {
+  if (length(x) != 1) {
     stop("Can only save length 1 node sets", call. = FALSE)
   }
 
   options  <- parse_options(options, xml_save_options())
+  con <- path_to_connection(con, check = "dir")
 
   if (inherits(con, "connection")) {
+    if (!isOpen(con)) {
+      open(con, "wb")
+      on.exit(close(con))
+    }
     node_write_connection(x[[1]]$node, con, options = options, encoding = encoding)
   } else {
     if (!(is.character(con) && length(con) == 1 && nzchar(con))) {
@@ -70,7 +80,12 @@ write_xml.xml_nodeset <- function(x, con, ..., options = "format", encoding = "U
 write_xml.xml_node <- function(x, con, format = TRUE, ..., options = "format", encoding = "UTF-8") {
   options  <- parse_options(options, xml_save_options())
 
+  con <- path_to_connection(con, check = "dir")
   if (inherits(con, "connection")) {
+    if (!isOpen(con)) {
+      open(con, "wb")
+      on.exit(close(con))
+    }
     node_write_connection(x$node, con, options = options, encoding = encoding)
   } else {
     if (!(is.character(con) && length(con) == 1 && nzchar(con))) {

--- a/R/xml_write.R
+++ b/R/xml_write.R
@@ -1,81 +1,97 @@
 #' Write XML or HTML to disk.
 #'
-#' This writes out both XML and normalised HTML.
+#' This writes out both XML and normalised HTML. The default behavior will
+#' output the same format which was read. If you want to force output pass
+#' \code{option = "as_xml"} or \code{option = "as_html"} respectively.
 #'
 #' @param x A document or node to write to disk. It's not possible to
 #'   save nodesets containing more than one node.
-#' @param file Path to file to write.
+#' @param con Path to file or connection to write to.
+#' @param encoding The character encoding to use in the document. The default
+#' encoding is \sQuote{UTF-8}. Available encodings are specified at
+#' \url{http://xmlsoft.org/html/libxml-encoding.html#xmlCharEncoding}.
+#' @param options default: \sQuote{format}. Zero or more of
+#' \Sexpr[results=rd]{xml2:::rd_definition(names(xml2:::xml_save_options()), attr(xml2:::xml_save_options(), "descriptions"))}
 #' @param ... additional arguments passed to methods.
-#' @param format if \code{TRUE}, the formatting spaces/lines are added to the
-#' output, if \code{FALSE} output is left as is.
 #' @export
 #' @examples
 #' h <- read_html("<p>Hi!</p>")
 #'
 #' tmp <- tempfile(fileext = ".xml")
-#' write_xml(h, tmp)
+#' write_xml(h, tmp, options = "format")
 #' readLines(tmp)
 #'
 #' # write formatted HTML output
-#' write_html(h, tmp, format = TRUE)
+#' write_html(h, tmp, options = "format")
 #' readLines(tmp)
-write_xml <- function(x, file, ...) {
+write_xml <- function(x, con, ...) {
   UseMethod("write_xml")
 }
 
 #' @export
-write_xml.xml_missing <- function(x, file, ...) {
+write_xml.xml_missing <- function(x, con, ...) {
   stop("Missing data cannot be written", call. = FALSE)
 }
 
 #' @rdname write_xml
 #' @export
-write_xml.xml_document <- function(x, file, format = TRUE, ...) {
-  doc_write_xml(x$doc, file, format)
+write_xml.xml_document <- function(x, con, ..., options = "format", encoding = "UTF-8") {
+  opts <- xml_save_options()
+  options  <- match.arg(options, names(opts), several.ok = TRUE)
+
+  if (inherits(con, "connection")) {
+    doc_write_connection(x$doc, con, options = sum(opts[options]), encoding = encoding)
+  } else {
+    doc_write(x$doc, con, options = sum(opts[options]), encoding = encoding)
+  }
 }
 
 #' @export
-write_xml.xml_nodeset <- function(x, file, ...) {
+write_xml.xml_nodeset <- function(x, con, ..., options = "format", encoding = "UTF-8") {
   if (length(x$nodeset) != 1) {
     stop("Can only save length 1 node sets", call. = FALSE)
   }
 
-  node_write_xml(x[[1]]$node, x$doc, file, ...)
+  opts <- xml_save_options()
+  options  <- match.arg(options, names(opts), several.ok = TRUE)
+
+  if (inherits(con, "connection")) {
+    node_write_connection(x[[1]]$node, con, options = sum(opts[options]), encoding = encoding)
+  } else {
+    node_write(x[[1]]$node, con, options = sum(opts[options]), encoding = encoding)
+  }
 }
 
 #' @export
-write_xml.xml_node <- function(x, file, format = TRUE, ...) {
-  node_write_xml(x$node, x$doc, file)
+write_xml.xml_node <- function(x, con, format = TRUE, ..., options = "format", encoding = "UTF-8") {
+  opts <- xml_save_options()
+  options  <- match.arg(options, names(opts), several.ok = TRUE)
+
+  if (inherits(con, "connection")) {
+    node_write_connection(x$node, con, options = sum(opts[options]), encoding = encoding)
+  } else {
+    node_write(x$node, con, options = sum(opts[options]), encoding = encoding)
+  }
 }
 
 
 #' @export
 #' @rdname write_xml
-write_html <- function(x, file, ...) {
+write_html <- function(x, con, ...) {
   UseMethod("write_html")
 }
 
 #' @export
-write_html.xml_missing <- function(x, file, ...) {
+write_html.xml_missing <- function(x, con, ...) {
   stop("Missing data cannot be written", call. = FALSE)
 }
 
 #' @rdname write_xml
 #' @export
-write_html.xml_document <- function(x, file, format = TRUE, ...) {
-  doc_write_html(x$doc, file, format)
-}
+write_html.xml_document <- write_xml.xml_document
 
 #' @export
-write_html.xml_nodeset <- function(x, file, ...) {
-  if (length(x$nodeset) != 1) {
-    stop("Can only save length 1 node sets", call. = FALSE)
-  }
-
-  node_write_html(x[[1]]$node, x$doc, file, ...)
-}
+write_html.xml_nodeset <- write_xml.xml_nodeset
 
 #' @export
-write_html.xml_node <- function(x, file, format = TRUE, ...) {
-  node_write_html(x$node, x$doc, file)
-}
+write_html.xml_node <- write_xml.xml_node

--- a/R/xml_write.R
+++ b/R/xml_write.R
@@ -11,7 +11,7 @@
 #' encoding is \sQuote{UTF-8}. Available encodings are specified at
 #' \url{http://xmlsoft.org/html/libxml-encoding.html#xmlCharEncoding}.
 #' @param options default: \sQuote{format}. Zero or more of
-#' \Sexpr[results=rd]{xml2:::rd_definition(names(xml2:::xml_save_options()), attr(xml2:::xml_save_options(), "descriptions"))}
+#' \Sexpr[results=rd]{xml2:::describe_options(xml2:::xml_save_options())}
 #' @param ... additional arguments passed to methods.
 #' @export
 #' @examples

--- a/R/xml_write.R
+++ b/R/xml_write.R
@@ -36,16 +36,15 @@ write_xml.xml_missing <- function(x, con, ...) {
 #' @rdname write_xml
 #' @export
 write_xml.xml_document <- function(x, con, ..., options = "format", encoding = "UTF-8") {
-  opts <- xml_save_options()
-  options  <- match.arg(options, names(opts), several.ok = TRUE)
+  options  <- parse_options(options, xml_save_options())
 
   if (inherits(con, "connection")) {
-    doc_write_connection(x$doc, con, options = sum(opts[options]), encoding = encoding)
+    doc_write_connection(x$doc, con, options = options, encoding = encoding)
   } else {
     if (!(is.character(con) && length(con) == 1 && nzchar(con))) {
       stop("`con` must be a non-zero character of length 1", call. = FALSE)
     }
-    doc_write(x$doc, normalizePath(con), options = sum(opts[options]), encoding = encoding)
+    doc_write(x$doc, normalize_output(con), options = options, encoding = encoding)
   }
 }
 
@@ -55,31 +54,29 @@ write_xml.xml_nodeset <- function(x, con, ..., options = "format", encoding = "U
     stop("Can only save length 1 node sets", call. = FALSE)
   }
 
-  opts <- xml_save_options()
-  options  <- match.arg(options, names(opts), several.ok = TRUE)
+  options  <- parse_options(options, xml_save_options())
 
   if (inherits(con, "connection")) {
-    node_write_connection(x[[1]]$node, con, options = sum(opts[options]), encoding = encoding)
+    node_write_connection(x[[1]]$node, con, options = options, encoding = encoding)
   } else {
     if (!(is.character(con) && length(con) == 1 && nzchar(con))) {
       stop("`con` must be a non-zero character of length 1", call. = FALSE)
     }
-    node_write(x[[1]]$node, normalizePath(con), options = sum(opts[options]), encoding = encoding)
+    node_write(x[[1]]$node, normalize_output(con), options = options, encoding = encoding)
   }
 }
 
 #' @export
 write_xml.xml_node <- function(x, con, format = TRUE, ..., options = "format", encoding = "UTF-8") {
-  opts <- xml_save_options()
-  options  <- match.arg(options, names(opts), several.ok = TRUE)
+  options  <- parse_options(options, xml_save_options())
 
   if (inherits(con, "connection")) {
-    node_write_connection(x$node, con, options = sum(opts[options]), encoding = encoding)
+    node_write_connection(x$node, con, options = options, encoding = encoding)
   } else {
     if (!(is.character(con) && length(con) == 1 && nzchar(con))) {
       stop("`con` must be a non-zero character of length 1", call. = FALSE)
     }
-    node_write(x$node, normalizePath(con), options = sum(opts[options]), encoding = encoding)
+    node_write(x$node, normalize_output(con), options = options, encoding = encoding)
   }
 }
 

--- a/R/xml_write.R
+++ b/R/xml_write.R
@@ -45,7 +45,7 @@ write_xml.xml_document <- function(x, con, ..., options = "format", encoding = "
     if (!(is.character(con) && length(con) == 1 && nzchar(con))) {
       stop("`con` must be a non-zero character of length 1", call. = FALSE)
     }
-    doc_write(x$doc, con, options = sum(opts[options]), encoding = encoding)
+    doc_write(x$doc, normalizePath(con), options = sum(opts[options]), encoding = encoding)
   }
 }
 
@@ -64,7 +64,7 @@ write_xml.xml_nodeset <- function(x, con, ..., options = "format", encoding = "U
     if (!(is.character(con) && length(con) == 1 && nzchar(con))) {
       stop("`con` must be a non-zero character of length 1", call. = FALSE)
     }
-    node_write(x[[1]]$node, con, options = sum(opts[options]), encoding = encoding)
+    node_write(x[[1]]$node, normalizePath(con), options = sum(opts[options]), encoding = encoding)
   }
 }
 
@@ -79,7 +79,7 @@ write_xml.xml_node <- function(x, con, format = TRUE, ..., options = "format", e
     if (!(is.character(con) && length(con) == 1 && nzchar(con))) {
       stop("`con` must be a non-zero character of length 1", call. = FALSE)
     }
-    node_write(x$node, con, options = sum(opts[options]), encoding = encoding)
+    node_write(x$node, normalizePath(con), options = sum(opts[options]), encoding = encoding)
   }
 }
 

--- a/R/xml_write.R
+++ b/R/xml_write.R
@@ -42,6 +42,9 @@ write_xml.xml_document <- function(x, con, ..., options = "format", encoding = "
   if (inherits(con, "connection")) {
     doc_write_connection(x$doc, con, options = sum(opts[options]), encoding = encoding)
   } else {
+    if (!(is.character(con) && length(con) == 1 && nzchar(con))) {
+      stop("`con` must be a non-zero character of length 1", call. = FALSE)
+    }
     doc_write(x$doc, con, options = sum(opts[options]), encoding = encoding)
   }
 }
@@ -58,6 +61,9 @@ write_xml.xml_nodeset <- function(x, con, ..., options = "format", encoding = "U
   if (inherits(con, "connection")) {
     node_write_connection(x[[1]]$node, con, options = sum(opts[options]), encoding = encoding)
   } else {
+    if (!(is.character(con) && length(con) == 1 && nzchar(con))) {
+      stop("`con` must be a non-zero character of length 1", call. = FALSE)
+    }
     node_write(x[[1]]$node, con, options = sum(opts[options]), encoding = encoding)
   }
 }
@@ -70,6 +76,9 @@ write_xml.xml_node <- function(x, con, format = TRUE, ..., options = "format", e
   if (inherits(con, "connection")) {
     node_write_connection(x$node, con, options = sum(opts[options]), encoding = encoding)
   } else {
+    if (!(is.character(con) && length(con) == 1 && nzchar(con))) {
+      stop("`con` must be a non-zero character of length 1", call. = FALSE)
+    }
     node_write(x$node, con, options = sum(opts[options]), encoding = encoding)
   }
 }

--- a/man/write_xml.Rd
+++ b/man/write_xml.Rd
@@ -26,7 +26,7 @@ save nodesets containing more than one node.}
 \item{...}{additional arguments passed to methods.}
 
 \item{options}{default: \sQuote{format}. Zero or more of
-\Sexpr[results=rd]{xml2:::rd_definition(names(xml2:::xml_save_options()), attr(xml2:::xml_save_options(), "descriptions"))}}
+\Sexpr[results=rd]{xml2:::describe_options(xml2:::xml_save_options())}}
 
 \item{encoding}{The character encoding to use in the document. The default
 encoding is \sQuote{UTF-8}. Available encodings are specified at

--- a/man/write_xml.Rd
+++ b/man/write_xml.Rd
@@ -7,36 +7,44 @@
 \alias{write_html.xml_document}
 \title{Write XML or HTML to disk.}
 \usage{
-write_xml(x, file, ...)
+write_xml(x, con, ...)
 
-\method{write_xml}{xml_document}(x, file, format = TRUE, ...)
+\method{write_xml}{xml_document}(x, con, ..., options = "format",
+  encoding = "UTF-8")
 
-write_html(x, file, ...)
+write_html(x, con, ...)
 
-\method{write_html}{xml_document}(x, file, format = TRUE, ...)
+\method{write_html}{xml_document}(x, con, ..., options = "format",
+  encoding = "UTF-8")
 }
 \arguments{
 \item{x}{A document or node to write to disk. It's not possible to
 save nodesets containing more than one node.}
 
-\item{file}{Path to file to write.}
+\item{con}{Path to file or connection to write to.}
 
 \item{...}{additional arguments passed to methods.}
 
-\item{format}{if \code{TRUE}, the formatting spaces/lines are added to the
-output, if \code{FALSE} output is left as is.}
+\item{options}{default: \sQuote{format}. Zero or more of
+\Sexpr[results=rd]{xml2:::rd_definition(names(xml2:::xml_save_options()), attr(xml2:::xml_save_options(), "descriptions"))}}
+
+\item{encoding}{The character encoding to use in the document. The default
+encoding is \sQuote{UTF-8}. Available encodings are specified at
+\url{http://xmlsoft.org/html/libxml-encoding.html#xmlCharEncoding}.}
 }
 \description{
-This writes out both XML and normalised HTML.
+This writes out both XML and normalised HTML. The default behavior will
+output the same format which was read. If you want to force output pass
+\code{option = "as_xml"} or \code{option = "as_html"} respectively.
 }
 \examples{
 h <- read_html("<p>Hi!</p>")
 
 tmp <- tempfile(fileext = ".xml")
-write_xml(h, tmp)
+write_xml(h, tmp, options = "format")
 readLines(tmp)
 
 # write formatted HTML output
-write_html(h, tmp, format = TRUE)
+write_html(h, tmp, options = "format")
 readLines(tmp)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -563,6 +563,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// doc_write_xml_connection
+void doc_write_xml_connection(XPtrDoc x, SEXP connection, bool format);
+RcppExport SEXP xml2_doc_write_xml_connection(SEXP xSEXP, SEXP connectionSEXP, SEXP formatSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtrDoc >::type x(xSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type connection(connectionSEXP);
+    Rcpp::traits::input_parameter< bool >::type format(formatSEXP);
+    doc_write_xml_connection(x, connection, format);
+    return R_NilValue;
+END_RCPP
+}
 // node_format_xml
 CharacterVector node_format_xml(XPtrDoc doc, XPtrNode node, bool format, int indent);
 RcppExport SEXP xml2_node_format_xml(SEXP docSEXP, SEXP nodeSEXP, SEXP formatSEXP, SEXP indentSEXP) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -491,54 +491,6 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
-// doc_write_xml
-void doc_write_xml(XPtrDoc x, std::string path, bool format);
-RcppExport SEXP xml2_doc_write_xml(SEXP xSEXP, SEXP pathSEXP, SEXP formatSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrDoc >::type x(xSEXP);
-    Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
-    Rcpp::traits::input_parameter< bool >::type format(formatSEXP);
-    doc_write_xml(x, path, format);
-    return R_NilValue;
-END_RCPP
-}
-// doc_write_html
-void doc_write_html(XPtrDoc x, std::string path, bool format);
-RcppExport SEXP xml2_doc_write_html(SEXP xSEXP, SEXP pathSEXP, SEXP formatSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrDoc >::type x(xSEXP);
-    Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
-    Rcpp::traits::input_parameter< bool >::type format(formatSEXP);
-    doc_write_html(x, path, format);
-    return R_NilValue;
-END_RCPP
-}
-// node_write_xml
-void node_write_xml(XPtrNode n, XPtrDoc d, std::string path);
-RcppExport SEXP xml2_node_write_xml(SEXP nSEXP, SEXP dSEXP, SEXP pathSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrNode >::type n(nSEXP);
-    Rcpp::traits::input_parameter< XPtrDoc >::type d(dSEXP);
-    Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
-    node_write_xml(n, d, path);
-    return R_NilValue;
-END_RCPP
-}
-// node_write_html
-void node_write_html(XPtrNode n, XPtrDoc d, std::string path);
-RcppExport SEXP xml2_node_write_html(SEXP nSEXP, SEXP dSEXP, SEXP pathSEXP) {
-BEGIN_RCPP
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< XPtrNode >::type n(nSEXP);
-    Rcpp::traits::input_parameter< XPtrDoc >::type d(dSEXP);
-    Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
-    node_write_html(n, d, path);
-    return R_NilValue;
-END_RCPP
-}
 // doc_format_xml
 CharacterVector doc_format_xml(XPtrDoc x, bool format);
 RcppExport SEXP xml2_doc_format_xml(SEXP xSEXP, SEXP formatSEXP) {
@@ -563,15 +515,65 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// doc_write_xml_connection
-void doc_write_xml_connection(XPtrDoc x, SEXP connection, bool format);
-RcppExport SEXP xml2_doc_write_xml_connection(SEXP xSEXP, SEXP connectionSEXP, SEXP formatSEXP) {
+// xml_save_options
+Rcpp::IntegerVector xml_save_options();
+RcppExport SEXP xml2_xml_save_options() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(xml_save_options());
+    return rcpp_result_gen;
+END_RCPP
+}
+// doc_write
+void doc_write(XPtrDoc x, std::string path, std::string encoding, int options);
+RcppExport SEXP xml2_doc_write(SEXP xSEXP, SEXP pathSEXP, SEXP encodingSEXP, SEXP optionsSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtrDoc >::type x(xSEXP);
+    Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
+    Rcpp::traits::input_parameter< std::string >::type encoding(encodingSEXP);
+    Rcpp::traits::input_parameter< int >::type options(optionsSEXP);
+    doc_write(x, path, encoding, options);
+    return R_NilValue;
+END_RCPP
+}
+// doc_write_connection
+void doc_write_connection(XPtrDoc x, SEXP connection, std::string encoding, int options);
+RcppExport SEXP xml2_doc_write_connection(SEXP xSEXP, SEXP connectionSEXP, SEXP encodingSEXP, SEXP optionsSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtrDoc >::type x(xSEXP);
     Rcpp::traits::input_parameter< SEXP >::type connection(connectionSEXP);
-    Rcpp::traits::input_parameter< bool >::type format(formatSEXP);
-    doc_write_xml_connection(x, connection, format);
+    Rcpp::traits::input_parameter< std::string >::type encoding(encodingSEXP);
+    Rcpp::traits::input_parameter< int >::type options(optionsSEXP);
+    doc_write_connection(x, connection, encoding, options);
+    return R_NilValue;
+END_RCPP
+}
+// node_write
+void node_write(XPtrNode x, std::string path, std::string encoding, int options);
+RcppExport SEXP xml2_node_write(SEXP xSEXP, SEXP pathSEXP, SEXP encodingSEXP, SEXP optionsSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtrNode >::type x(xSEXP);
+    Rcpp::traits::input_parameter< std::string >::type path(pathSEXP);
+    Rcpp::traits::input_parameter< std::string >::type encoding(encodingSEXP);
+    Rcpp::traits::input_parameter< int >::type options(optionsSEXP);
+    node_write(x, path, encoding, options);
+    return R_NilValue;
+END_RCPP
+}
+// node_write_connection
+void node_write_connection(XPtrNode x, SEXP connection, std::string encoding, int options);
+RcppExport SEXP xml2_node_write_connection(SEXP xSEXP, SEXP connectionSEXP, SEXP encodingSEXP, SEXP optionsSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtrNode >::type x(xSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type connection(connectionSEXP);
+    Rcpp::traits::input_parameter< std::string >::type encoding(encodingSEXP);
+    Rcpp::traits::input_parameter< int >::type options(optionsSEXP);
+    node_write_connection(x, connection, encoding, options);
     return R_NilValue;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -18,6 +18,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// xml_parse_options
+Rcpp::IntegerVector xml_parse_options();
+RcppExport SEXP xml2_xml_parse_options() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(xml_parse_options());
+    return rcpp_result_gen;
+END_RCPP
+}
 // doc_parse_file
 XPtrDoc doc_parse_file(std::string path, std::string encoding, bool as_html, int options);
 RcppExport SEXP xml2_doc_parse_file(SEXP pathSEXP, SEXP encodingSEXP, SEXP as_htmlSEXP, SEXP optionsSEXP) {

--- a/src/xml2_doc.cpp
+++ b/src/xml2_doc.cpp
@@ -7,6 +7,102 @@ using namespace Rcpp;
 #include "xml2_utils.h"
 
 // [[Rcpp::export]]
+Rcpp::IntegerVector xml_parse_options() {
+  const char * names[] = {
+    "RECOVER",
+    "NOENT",
+    "DTDLOAD",
+    "DTDATTR",
+    "DTDVALID",
+    "NOERROR",
+    "NOWARNING",
+    "PEDANTIC",
+    "NOBLANKS",
+    "SAX1",
+    "XINCLUDE",
+    "NONET",
+    "NODICT",
+    "NSCLEAN",
+    "NOCDATA",
+    "NOXINCNODE",
+    "COMPACT",
+    "OLD10",
+    "NOBASEFIX",
+    "HUGE",
+    "OLDSAX",
+    "IGNORE_ENC",
+    "BIG_LINES",
+  };
+
+  const int values[] = {
+    XML_PARSE_RECOVER,
+    XML_PARSE_NOENT,
+    XML_PARSE_DTDLOAD,
+    XML_PARSE_DTDATTR,
+    XML_PARSE_DTDVALID,
+    XML_PARSE_NOERROR,
+    XML_PARSE_NOWARNING,
+    XML_PARSE_PEDANTIC,
+    XML_PARSE_NOBLANKS,
+    XML_PARSE_SAX1,
+    XML_PARSE_XINCLUDE,
+    XML_PARSE_NONET,
+    XML_PARSE_NODICT,
+    XML_PARSE_NSCLEAN,
+    XML_PARSE_NOCDATA,
+    XML_PARSE_NOXINCNODE,
+    XML_PARSE_COMPACT,
+    XML_PARSE_OLD10,
+    XML_PARSE_NOBASEFIX,
+    XML_PARSE_HUGE,
+    XML_PARSE_OLDSAX,
+    XML_PARSE_IGNORE_ENC,
+    XML_PARSE_BIG_LINES,
+  };
+
+  const char * descriptions[] = {
+    "recover on errors",
+    "substitute entities",
+    "load the external subset",
+    "default DTD attributes",
+    "validate with the DTD",
+    "suppress error reports",
+    "suppress warning reports",
+    "pedantic error reporting",
+    "remove blank nodes",
+    "use the SAX1 interface internally",
+    "Implement XInclude substitition",
+    "Forbid network access",
+    "Do not reuse the context dictionary",
+    "remove redundant namespaces declarations",
+    "merge CDATA as text nodes",
+    "do not generate XINCLUDE START/END nodes",
+    "compact small text nodes; no modification of the tree allowed afterwards (will possibly crash if you try to modify the tree)",
+    "parse using XML-1.0 before update 5",
+    "do not fixup XINCLUDE xml:base uris",
+    "relax any hardcoded limit from the parser",
+    "parse using SAX2 interface before 2.7.0",
+    "ignore internal document encoding hint",
+    "Store big lines numbers in text PSVI field",
+  };
+
+  size_t size = sizeof(values) / sizeof(values[0]);
+
+  Rcpp::IntegerVector out_values = Rcpp::IntegerVector(size);
+  Rcpp::CharacterVector out_names = Rcpp::CharacterVector(size);
+  Rcpp::CharacterVector out_descriptions = Rcpp::CharacterVector(size);
+  for (int i = 0; i < size; ++i) {
+    out_values[i] = values[i];
+    out_names[i] = names[i];
+    out_descriptions[i] = descriptions[i];
+  }
+  out_values.attr("names") = out_names;
+  out_values.attr("descriptions") = out_descriptions;
+
+  return out_values;
+}
+
+// [[Rcpp::export]]
 XPtrDoc doc_parse_file(std::string path,
                             std::string encoding = "",
                             bool as_html = false,

--- a/src/xml2_doc.cpp
+++ b/src/xml2_doc.cpp
@@ -8,6 +8,16 @@ using namespace Rcpp;
 
 // [[Rcpp::export]]
 Rcpp::IntegerVector xml_parse_options() {
+
+  /* * *
+   * Author: Daniel Veillard <veillard@redhat.com>
+   * Date:   Mon Aug 13 12:41:33 2012 +0800
+   * https://github.com/GNOME/libxml2/commit/968a03a2e54f5bcf53089f5e3c8f790dbe0bf824
+   */
+#if defined(LIBXML_VERSION) && (LIBXML_VERSION >= 20900)
+#define HAS_BIG_LINES
+#endif
+
   const char * names[] = {
     "RECOVER",
     "NOENT",
@@ -31,7 +41,9 @@ Rcpp::IntegerVector xml_parse_options() {
     "HUGE",
     "OLDSAX",
     "IGNORE_ENC",
+#ifdef HAS_BIG_LINES
     "BIG_LINES",
+#endif
   };
 
   const int values[] = {
@@ -57,7 +69,9 @@ Rcpp::IntegerVector xml_parse_options() {
     XML_PARSE_HUGE,
     XML_PARSE_OLDSAX,
     XML_PARSE_IGNORE_ENC,
+#ifdef HAS_BIG_LINES
     XML_PARSE_BIG_LINES,
+#endif
   };
 
   const char * descriptions[] = {
@@ -83,7 +97,9 @@ Rcpp::IntegerVector xml_parse_options() {
     "relax any hardcoded limit from the parser",
     "parse using SAX2 interface before 2.7.0",
     "ignore internal document encoding hint",
+#ifdef HAS_BIG_LINES
     "Store big lines numbers in text PSVI field",
+#endif
   };
 
   size_t size = sizeof(values) / sizeof(values[0]);
@@ -100,6 +116,8 @@ Rcpp::IntegerVector xml_parse_options() {
   out_values.attr("descriptions") = out_descriptions;
 
   return out_values;
+
+  #undef HAS_BIG_LINES
 }
 
 // [[Rcpp::export]]

--- a/src/xml2_doc.cpp
+++ b/src/xml2_doc.cpp
@@ -11,8 +11,21 @@ Rcpp::IntegerVector xml_parse_options() {
 
   /* * *
    * Author: Daniel Veillard <veillard@redhat.com>
+   * Date:   Mon May 16 16:03:50 2011 +0800
+   * https://github.com/GNOME/libxml2/commit/c62efc847c836d4c4f1aea08c68cd93bd342b9f4
+   *
+   * Add options to ignore the internal encoding
+   */
+#if defined(LIBXML_VERSION) && (LIBXML_VERSION >= 20800)
+#define HAS_IGNORE_ENC
+#endif
+
+  /* * *
+   * Author: Daniel Veillard <veillard@redhat.com>
    * Date:   Mon Aug 13 12:41:33 2012 +0800
    * https://github.com/GNOME/libxml2/commit/968a03a2e54f5bcf53089f5e3c8f790dbe0bf824
+   *
+   * Add support for big line numbers in error reporting
    */
 #if defined(LIBXML_VERSION) && (LIBXML_VERSION >= 20900)
 #define HAS_BIG_LINES
@@ -40,7 +53,9 @@ Rcpp::IntegerVector xml_parse_options() {
     "NOBASEFIX",
     "HUGE",
     "OLDSAX",
+#ifdef HAS_IGNORE_ENC
     "IGNORE_ENC",
+#endif
 #ifdef HAS_BIG_LINES
     "BIG_LINES",
 #endif
@@ -68,7 +83,9 @@ Rcpp::IntegerVector xml_parse_options() {
     XML_PARSE_NOBASEFIX,
     XML_PARSE_HUGE,
     XML_PARSE_OLDSAX,
+#ifdef HAS_IGNORE_ENC
     XML_PARSE_IGNORE_ENC,
+#endif
 #ifdef HAS_BIG_LINES
     XML_PARSE_BIG_LINES,
 #endif
@@ -96,7 +113,9 @@ Rcpp::IntegerVector xml_parse_options() {
     "do not fixup XINCLUDE xml:base uris",
     "relax any hardcoded limit from the parser",
     "parse using SAX2 interface before 2.7.0",
+#ifdef HAS_IGNORE_ENC
     "ignore internal document encoding hint",
+#endif
 #ifdef HAS_BIG_LINES
     "Store big lines numbers in text PSVI field",
 #endif
@@ -117,7 +136,8 @@ Rcpp::IntegerVector xml_parse_options() {
 
   return out_values;
 
-  #undef HAS_BIG_LINES
+#undef HAS_BIG_LINES
+#undef HAS_IGNORE_ENC
 }
 
 // [[Rcpp::export]]

--- a/src/xml2_output.cpp
+++ b/src/xml2_output.cpp
@@ -100,8 +100,8 @@ void doc_write_connection(XPtrDoc x, SEXP connection, std::string encoding = "UT
   }
 
   xmlSaveCtxtPtr savectx = xmlSaveToIO(
-      (xmlOutputWriteCallback)xml_write_callback,
-      (xmlOutputCloseCallback) xml_close_callback,
+      reinterpret_cast<xmlOutputWriteCallback>(xml_write_callback),
+      reinterpret_cast<xmlOutputCloseCallback>(xml_close_callback),
       &ctxt,
       encoding.c_str(),
       options);

--- a/tests/testthat/test-read-xml.R
+++ b/tests/testthat/test-read-xml.R
@@ -6,11 +6,22 @@ test_that("read_html correctly parses malformed document", {
 })
 
 test_that("parse_options errors when given an invalid option", {
-  expect_error(parse_options("INVALID"),
-    "`options` INVALID is not a valid option")
+  expect_error(parse_options("INVALID", xml_parse_options()),
+    "`options` 'INVALID' is not a valid option")
 
   expect_error(read_html("lego.html.bz2", options = "INVALID"),
-    "`options` INVALID is not a valid option")
+    "`options` 'INVALID' is not a valid option")
+
+  # Empty inputs returned as 0
+  expect_identical(0L, parse_options("", xml_parse_options()))
+  expect_identical(0L, parse_options(NULL, xml_parse_options()))
+
+  # Numerics returned as integers
+  expect_identical(12L, parse_options(12L, xml_parse_options()))
+  expect_identical(12L, parse_options(12, xml_parse_options()))
+
+  # Multiple inputs summed
+  expect_identical(3L, parse_options(c("RECOVER", "NOENT"), xml_parse_options()))
 })
 
 test_that("read_html properly passes parser arguments", {

--- a/tests/testthat/test-write_xml.R
+++ b/tests/testthat/test-write_xml.R
@@ -1,0 +1,112 @@
+context("write_xml")
+
+test_that("write_xml errors for incorrect directory and with invalid inputs", {
+  x <- read_xml("<x/>")
+  filename <- ".../test.xml"
+  expect_error(write_xml(x, filename), "'...' does not exist in current working directory")
+
+
+  expect_error(write_xml(x, c("test.xml", "foo")), "`con` must be a non-zero character of length 1")
+})
+
+test_that("write_xml works with relative file paths", {
+  x <- read_xml("<x/>")
+
+  filename <- "../test.xml"
+  on.exit(unlink(filename))
+  write_xml(x, filename, options = "no_declaration")
+  expect_identical(readChar(filename, 1000L), "<x/>\n")
+})
+
+test_that("write_xml works with no options", {
+  x <- read_xml("<x/>")
+
+  filename <- "../test.xml"
+  on.exit(unlink(filename))
+  write_xml(x, filename, options = NULL)
+  expect_identical(readChar(filename, 1000L), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<x/>\n")
+})
+
+test_that("write_xml works with an explicit connections", {
+  x <- read_xml("<x/>")
+
+  filename <- "../test.xml"
+  con <- file(filename, "wb")
+  on.exit(unlink(filename))
+  write_xml(x, con, options = "no_declaration")
+  close(con)
+  expect_identical(readChar(filename, 1000L), "<x/>\n")
+})
+
+test_that("write_xml works with an implicit connections", {
+  x <- read_xml("<x/>")
+
+  filename <- "../test.xml.gz"
+  write_xml(x, filename, options = "no_declaration")
+  con <- gzfile(filename, "rb")
+  on.exit({unlink(filename); close(con)})
+  expect_identical(readChar(con, 1000L), "<x/>\n")
+})
+
+test_that("write_xml works with nodeset input and files", {
+  x <- read_xml("<x><y/><y/></x>")
+  y <- xml_find_all(x, "//y")
+
+  filename <- "../test.xml"
+  on.exit(unlink(filename))
+  expect_error(write_xml(y, filename, options = "no_declaration"),
+    "Can only save length 1 node sets")
+
+  write_xml(y[1], filename, options = "no_declaration")
+  expect_identical(readChar(filename, 1000L), "<y/>")
+})
+
+test_that("write_xml works with nodeset input and connections", {
+  x <- read_xml("<x><y/><y/></x>")
+  y <- xml_find_all(x, "//y")
+
+  filename <- "../test.xml.gz"
+  expect_error(write_xml(y, filename, options = "no_declaration"),
+    "Can only save length 1 node sets")
+
+  expect_error(write_xml(y[1], c(filename, "foo")), "`con` must be a non-zero character of length 1")
+
+  write_xml(y[1], filename, options = "no_declaration")
+  con <- gzfile(filename, "rb")
+  on.exit({unlink(filename); close(con)})
+  expect_identical(readChar(con, 1000L), "<y/>")
+})
+
+test_that("write_xml works with node input and files", {
+  x <- read_xml("<x><y/><y/></x>")
+  y <- xml_find_first(x, "//y")
+
+  filename <- "../test.xml"
+  expect_error(write_xml(y, c(filename, "foo")), "`con` must be a non-zero character of length 1")
+
+  write_xml(y, filename, options = "no_declaration")
+  on.exit(unlink(filename))
+  expect_identical(readChar(filename, 1000L), "<y/>")
+})
+
+test_that("write_xml works with node input and connections", {
+  x <- read_xml("<x><y/><y/></x>")
+  y <- xml_find_first(x, "//y")
+
+  filename <- "../test.xml.gz"
+  write_xml(y, filename, options = "no_declaration")
+  con <- gzfile(filename, "rb")
+  on.exit({unlink(filename); close(con)})
+  expect_identical(readChar(con, 1000L), "<y/>")
+})
+
+test_that("write_html work with html input", {
+  x <- read_html("<html><title>Foo</title></html>")
+
+  filename <- "../test.html.gz"
+  write_html(x, filename)
+  con <- gzfile(filename, "rb")
+  on.exit({unlink(filename); close(con)})
+  expect_identical(readChar(con, 1000L),
+    "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.0 Transitional//EN\" \"http://www.w3.org/TR/REC-html40/loose.dtd\">\n<html><head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n<title>Foo</title>\n</head></html>\n")
+})

--- a/tests/testthat/test-xml_missing.R
+++ b/tests/testthat/test-xml_missing.R
@@ -22,6 +22,7 @@ test_that("xml_missing methods return properly for all S3 methods", {
   expect_output(print(mss), "\\{xml_missing\\}\n<NA>")
   expect_equal(tree_structure(mss), NA_character_)
   expect_error(write_xml(mss), "Missing data cannot be written")
+  expect_error(write_html(mss), "Missing data cannot be written")
   expect_equal(xml_attr(mss), NA_character_)
   expect_equal(xml_attrs(mss), NA_character_)
   expect_equal(xml_find_all(mss), xml_nodeset())


### PR DESCRIPTION
This provides full connection support for XML and HTML output using the
xmlSave API (http://xmlsoft.org/html/libxml-xmlsave.html). It also
refactors the file output functions to use the xmlSave API as well,
which provides more formatting and encoding options than the previous
APIs.

Closes #157