### PR TITLE
Add child node performance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# xml2 1.1.2
+
+* `xml_add_child()` now requires less resources to insert a node when called
+  with `.where = 0L` (@heckendorfc, #175).
+
 # xml2 1.1.1
 
 * This is a small point release addressing installation issues found with older

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -89,6 +89,10 @@ node_length <- function(node, onlyNode = TRUE) {
     .Call('xml2_node_length', PACKAGE = 'xml2', node, onlyNode)
 }
 
+node_has_children <- function(node) {
+    .Call('xml2_node_has_children', PACKAGE = 'xml2', node)
+}
+
 node_parents <- function(node) {
     .Call('xml2_node_parents', PACKAGE = 'xml2', node)
 }
@@ -127,6 +131,10 @@ node_append_content <- function(node, content) {
 
 node_append_child <- function(parent, cur) {
     .Call('xml2_node_append_child', PACKAGE = 'xml2', parent, cur)
+}
+
+node_prepend_child <- function(parent, cur) {
+    .Call('xml2_node_prepend_child', PACKAGE = 'xml2', parent, cur)
 }
 
 node_prepend_sibling <- function(cur, elem) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -89,8 +89,8 @@ node_length <- function(node, onlyNode = TRUE) {
     .Call('xml2_node_length', PACKAGE = 'xml2', node, onlyNode)
 }
 
-node_has_children <- function(node) {
-    .Call('xml2_node_has_children', PACKAGE = 'xml2', node)
+node_has_children <- function(node, onlyNode = TRUE) {
+    .Call('xml2_node_has_children', PACKAGE = 'xml2', node, onlyNode)
 }
 
 node_parents <- function(node) {

--- a/R/xml_modify.R
+++ b/R/xml_modify.R
@@ -147,14 +147,17 @@ xml_add_child.xml_node <- function(.x, .value, ..., .where = length(xml_children
 
   node <- create_node(.value, .x, .copy = .copy, ...)
 
-  num_children <- length(xml_children(.x))
-
-  if (.where >= num_children) {
-    node_append_child(.x$node, node$node)
-  } else if (.where == 0L) {
-    node_prepend_sibling(xml_child(.x, search = 1)$node, node$node)
+  if (.where == 0L) {
+    if(node_has_children(.x$node))
+      node_prepend_child(.x$node, node$node)
+    else
+      node_append_child(.x$node, node$node)
   } else {
-    node_append_sibling(xml_child(.x, search = .where)$node, node$node)
+    num_children <- length(xml_children(.x))
+    if (.where >= num_children) {
+      node_append_child(.x$node, node$node)
+    } else
+      node_append_sibling(xml_child(.x, search = .where)$node, node$node)
   }
 
   invisible(node)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -270,13 +270,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // node_has_children
-bool node_has_children(XPtrNode node);
-RcppExport SEXP xml2_node_has_children(SEXP nodeSEXP) {
+bool node_has_children(XPtrNode node, bool onlyNode);
+RcppExport SEXP xml2_node_has_children(SEXP nodeSEXP, SEXP onlyNodeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtrNode >::type node(nodeSEXP);
-    rcpp_result_gen = Rcpp::wrap(node_has_children(node));
+    Rcpp::traits::input_parameter< bool >::type onlyNode(onlyNodeSEXP);
+    rcpp_result_gen = Rcpp::wrap(node_has_children(node, onlyNode));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -269,6 +269,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// node_has_children
+bool node_has_children(XPtrNode node);
+RcppExport SEXP xml2_node_has_children(SEXP nodeSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtrNode >::type node(nodeSEXP);
+    rcpp_result_gen = Rcpp::wrap(node_has_children(node));
+    return rcpp_result_gen;
+END_RCPP
+}
 // node_parents
 Rcpp::List node_parents(XPtrNode node);
 RcppExport SEXP xml2_node_parents(SEXP nodeSEXP) {
@@ -378,6 +389,18 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< XPtrNode >::type parent(parentSEXP);
     Rcpp::traits::input_parameter< XPtrNode >::type cur(curSEXP);
     rcpp_result_gen = Rcpp::wrap(node_append_child(parent, cur));
+    return rcpp_result_gen;
+END_RCPP
+}
+// node_prepend_child
+XPtrNode node_prepend_child(XPtrNode parent, XPtrNode cur);
+RcppExport SEXP xml2_node_prepend_child(SEXP parentSEXP, SEXP curSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< XPtrNode >::type parent(parentSEXP);
+    Rcpp::traits::input_parameter< XPtrNode >::type cur(curSEXP);
+    rcpp_result_gen = Rcpp::wrap(node_prepend_child(parent, cur));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/xml2_node.cpp
+++ b/src/xml2_node.cpp
@@ -364,6 +364,10 @@ int node_length(XPtrNode node, bool onlyNode = true) {
   return i;
 }
 
+// [[Rcpp::export]]
+bool node_has_children(XPtrNode node) {
+  return node->xmlChildrenNode != NULL;
+}
 
 // [[Rcpp::export]]
 Rcpp::List node_parents(XPtrNode node) {
@@ -459,6 +463,11 @@ void node_append_content(XPtrNode node, std::string content) {
 // [[Rcpp::export]]
 XPtrNode node_append_child(XPtrNode parent, XPtrNode cur) {
   return XPtrNode(xmlAddChild(parent.checked_get(), cur.checked_get()));
+}
+
+// [[Rcpp::export]]
+XPtrNode node_prepend_child(XPtrNode parent, XPtrNode cur) {
+  return XPtrNode(xmlAddPrevSibling(parent.checked_get()->children, cur.checked_get()));
 }
 
 // Previous sibling

--- a/src/xml2_node.cpp
+++ b/src/xml2_node.cpp
@@ -365,8 +365,13 @@ int node_length(XPtrNode node, bool onlyNode = true) {
 }
 
 // [[Rcpp::export]]
-bool node_has_children(XPtrNode node) {
-  return node->xmlChildrenNode != NULL;
+bool node_has_children(XPtrNode node, bool onlyNode = true) {
+  for(xmlNode* cur = node->xmlChildrenNode; cur != NULL; cur = cur->next) {
+    if (onlyNode && cur->type != XML_ELEMENT_NODE)
+      continue;
+    return true;
+  }
+  return false;
 }
 
 // [[Rcpp::export]]


### PR DESCRIPTION
I generate XML documents which can easily have nodes with >10k children. With the current logic in this package, there is no way to add child nodes without iterating through or creating R objects containing the complete list of children.

I restructured xml_add_child so that using `.where=0L` (prepend mode) will bypass these very slow function calls.

With the existing code, using `.where=0L` will produce an error if there are no children, rather than just insert the node as the first and only child. I assume this is a bug so I also included a fix for this in my changes.